### PR TITLE
Foxhoundn/enhancement-removable-228

### DIFF
--- a/__tests__/popover.test.tsx
+++ b/__tests__/popover.test.tsx
@@ -109,9 +109,9 @@ test('Runs callback function', async () => {
   fireEvent.mouseLeave(screen.getByText('Hover me'));
 });
 
-test('Shows the popover after a delay', async () => {
+test('Shows the popover after a local delay, ignoring global delay', async () => {
   render(
-    <ReqoreUIProvider>
+    <ReqoreUIProvider options={{ tooltips: { delay: 1000 } }}>
       <SimpleContent delay={500} />
     </ReqoreUIProvider>
   );
@@ -123,6 +123,28 @@ test('Shows the popover after a delay', async () => {
   expect(document.querySelectorAll('.reqore-popover-content').length).toBe(0);
 
   jest.advanceTimersByTime(400);
+
+  expect(document.querySelectorAll('.reqore-popover-content').length).toBe(1);
+
+  fireEvent.mouseLeave(screen.getByText('Hover me'));
+
+  expect(document.querySelectorAll('.reqore-popover-content').length).toBe(0);
+});
+
+test('Shows the popover after a global delay', async () => {
+  render(
+    <ReqoreUIProvider options={{ tooltips: { delay: 1000 } }}>
+      <SimpleContent />
+    </ReqoreUIProvider>
+  );
+
+  fireEvent.mouseEnter(screen.getByText('Hover me'));
+
+  jest.advanceTimersByTime(500);
+
+  expect(document.querySelectorAll('.reqore-popover-content').length).toBe(0);
+
+  jest.advanceTimersByTime(500);
 
   expect(document.querySelectorAll('.reqore-popover-content').length).toBe(1);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.29.8",
+  "version": "0.29.9",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -161,7 +161,7 @@ export const StyledButton = styled(StyledEffect)<IReqoreButtonStyle>`
 
   min-height: ${({ size }) => SIZE_TO_PX[size]}px;
   min-width: ${({ size }) => SIZE_TO_PX[size]}px;
-  max-width: ${({ maxWidth }) => maxWidth || undefined};
+  max-width: ${({ maxWidth, fluid, fixed }) => maxWidth || (fluid && !fixed ? '100%' : undefined)};
   ${({ wrap, description }) =>
     !wrap && !description
       ? css`
@@ -170,7 +170,6 @@ export const StyledButton = styled(StyledEffect)<IReqoreButtonStyle>`
       : null}
 
   flex: ${({ fluid, fixed }) => (fixed ? '0 0 auto' : fluid ? '1 auto' : '0 0 auto')};
-  max-width: ${({ fluid, fixed }) => (fluid && !fixed ? '100%' : undefined)};
 
   border-radius: ${({ size }) => RADIUS_FROM_SIZE[size]}px;
 

--- a/src/components/Collection/index.tsx
+++ b/src/components/Collection/index.tsx
@@ -22,6 +22,11 @@ export interface IReqoreCollectionProps
       | 'label'
       | 'headerSize'
       | 'badge'
+      | 'icon'
+      | 'flat'
+      | 'minimal'
+      | 'transparent'
+      | 'fluid'
     >,
     IReqoreColumnsProps {
   items?: IReqoreCollectionItemProps[];
@@ -35,6 +40,7 @@ export interface IReqoreCollectionProps
   showAs?: 'list' | 'grid';
   showSelectedFirst?: boolean;
   selectedIcon?: IReqoreIconName;
+  emptyMessage?: string;
 }
 
 export const StyledCollectionWrapper = styled(StyledColumns)`
@@ -64,6 +70,10 @@ export const ReqoreCollection = ({
   headerSize = 2,
   showAs = 'grid',
   selectedIcon,
+  flat = true,
+  minimal,
+  transparent = true,
+  emptyMessage = 'No data in this collection, try changing your search query or filters',
   ...rest
 }: IReqoreCollectionProps) => {
   const [_showAs, setShowAs] = useState<'list' | 'grid'>(showAs);
@@ -199,17 +209,20 @@ export const ReqoreCollection = ({
       {...rest}
       headerSize={headerSize}
       style={{
+        ...rest.style,
         height: height ?? undefined,
       }}
       fill={fill}
       padded
-      opacity={0}
+      transparent={transparent}
+      minimal={minimal}
+      flat={flat}
       actions={finalActions}
       className={`reqore-collection ${rest.className || ''}`}
     >
       {!size(finalItems) ? (
         <ReqoreMessage intent='muted' flat title='No items found'>
-          No data in this collection, try changing your search query or filters
+          {emptyMessage}
         </ReqoreMessage>
       ) : (
         <StyledCollectionWrapper

--- a/src/components/Collection/item.tsx
+++ b/src/components/Collection/item.tsx
@@ -7,7 +7,6 @@ import ReqoreContext from '../../context/ReqoreContext';
 import { changeDarkness, getMainBackgroundColor } from '../../helpers/colors';
 import { useReqoreTheme } from '../../hooks/useTheme';
 import { StyledBackdrop } from '../Drawer';
-import { IReqoreDropdownItem } from '../Dropdown/list';
 import {
   IReqorePanelAction,
   IReqorePanelBottomAction,
@@ -36,7 +35,7 @@ export interface IReqoreCollectionItemProps
   expandedContent?: string | React.ReactNode;
   expandedActions?: IReqorePanelBottomAction[];
   image?: string;
-  actions?: IReqoreDropdownItem[];
+  actions?: IReqorePanelAction[];
   tags?: IReqoreTagProps[];
   maxContentHeight?: number;
   showContentFade?: boolean;
@@ -44,9 +43,10 @@ export interface IReqoreCollectionItemProps
 
 export const StyledCollectionItemContent = styled.div`
   max-height: ${({ providedHeight }) => (providedHeight ? `${providedHeight}px` : 'auto')};
-  overflow: hidden;
+  overflow: ${({ isSelected }) => (isSelected ? 'auto' : 'hidden')};
   position: relative;
   transition: 0.3s ease-in-out;
+  flex: 1;
 
   ${({ contentOverflows, theme, opacity = 1 }) =>
     contentOverflows &&
@@ -185,7 +185,7 @@ export const ReqoreCollectionItem = ({
           { icon: 'CloseLine', onClick: handleItemClick },
         ] as IReqorePanelAction[])
       : size(actions)
-      ? [{ icon: 'More2Fill', actions, minimal: true, flat: true }]
+      ? actions
       : undefined;
 
     return (
@@ -215,15 +215,23 @@ export const ReqoreCollectionItem = ({
             ...dimensions,
             transformOrigin: 'center',
           }}
+          contentStyle={{
+            ...rest.contentStyle,
+            display: 'flex',
+            flexFlow: 'column',
+            justifyContent: 'space-between',
+          }}
           onClick={(expandable && !isSelected) || rest.onClick ? handleItemClick : undefined}
           actions={actualActions}
           className={`reqore-collection-item ${rest.className || ''}`}
         >
           <StyledCollectionItemContent
             theme={theme}
-            opacity={rest.opacity}
+            opacity={rest.transparent ? 0 : rest.opacity}
             providedHeight={isSelected ? undefined : maxContentHeight}
+            isSelected={isSelected}
             contentOverflows={
+              !rest.transparent &&
               !rest.contentEffect &&
               !isSelected &&
               sizes?.height > maxContentHeight &&
@@ -233,7 +241,7 @@ export const ReqoreCollectionItem = ({
             <div ref={contentRef}>{actualContent}</div>
           </StyledCollectionItemContent>
           {showContentFade &&
-          rest.contentEffect &&
+          (rest.contentEffect || rest.transparent) &&
           !isSelected &&
           sizes?.height > maxContentHeight ? (
             <ReqoreP>...</ReqoreP>

--- a/src/components/ControlGroup/index.tsx
+++ b/src/components/ControlGroup/index.tsx
@@ -24,6 +24,8 @@ export interface IReqoreControlGroupProps
    * Whether the contents of the control group should be stacked vertically
    */
   vertical?: boolean;
+  verticalAlign?: 'flex-start' | 'center' | 'flex-end';
+  horizontalAlign?: 'flex-start' | 'center' | 'flex-end';
   wrap?: boolean;
   isInsideStackGroup?: boolean;
   isInsideVerticalGroup?: boolean;
@@ -47,7 +49,10 @@ export const StyledReqoreControlGroup = styled.div<IReqoreControlGroupStyle>`
   display: flex;
   flex: 0 auto;
   width: ${({ fluid }) => (fluid ? '100%' : undefined)};
-  align-items: ${({ fluid }) => (fluid ? 'stretch' : 'flex-start')};
+  justify-content: ${({ fluid, vertical, horizontalAlign, verticalAlign }) =>
+    vertical ? verticalAlign : fluid ? 'stretch' : horizontalAlign};
+  align-items: ${({ vertical, horizontalAlign, verticalAlign, fluid }) =>
+    vertical ? (fluid ? 'stretch' : horizontalAlign) : verticalAlign};
   flex-flow: ${({ vertical }) => (vertical ? 'column' : 'row')};
   gap: ${({ gapSize, stack }) => (!stack ? `${GAP_FROM_SIZE[gapSize]}px` : undefined)};
   flex-wrap: ${({ wrap }) => (wrap ? 'wrap' : 'nowrap')};
@@ -85,6 +90,8 @@ const ReqoreControlGroup = memo(
         isChild,
         isFirstGroup,
         isLastGroup,
+        verticalAlign = 'center',
+        horizontalAlign = 'flex-start',
         ...rest
       }: IReqoreControlGroupProps,
       ref
@@ -313,6 +320,8 @@ const ReqoreControlGroup = memo(
           fluid={fluid}
           wrap={wrap}
           stack={isStack}
+          verticalAlign={verticalAlign}
+          horizontalAlign={horizontalAlign}
           className={`${className || ''} reqore-control-group`}
         >
           {cloneThroughFragments(children)}

--- a/src/components/Tabs/content.tsx
+++ b/src/components/Tabs/content.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 
+export type TReqoreTabsContentPadding = 'horizontal' | 'vertical' | 'none' | 'both' | true | false;
+
 export interface IReqoreTabsContent extends React.HTMLAttributes<HTMLDivElement> {
   children?: any;
   tabId: string | number;
+  padded?: TReqoreTabsContentPadding;
 }
 
 const StyledTabsContent = styled.div`
@@ -11,11 +14,16 @@ const StyledTabsContent = styled.div`
   flex-flow: column;
   overflow: hidden;
   flex: 1;
-  padding: 10px;
+  padding: ${({ padded }: IReqoreTabsContent) =>
+    padded === 'none' || padded === false
+      ? undefined
+      : `${padded === 'both' || padded === true || padded === 'vertical' ? 10 : 0}px ${
+          padded === 'both' || padded === true || padded === 'horizontal' ? 10 : 0
+        }px}`};
 `;
 
-const ReqoreTabsContent = ({ children, className, ...rest }: IReqoreTabsContent) => (
-  <StyledTabsContent {...rest} className={`${className || ''} reqore-tabs-content`}>
+const ReqoreTabsContent = ({ children, className, padded = true, ...rest }: IReqoreTabsContent) => (
+  <StyledTabsContent {...rest} padded={padded} className={`${className || ''} reqore-tabs-content`}>
     {children}
   </StyledTabsContent>
 );

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -4,6 +4,7 @@ import { TSizes } from '../../constants/sizes';
 import { IReqoreCustomTheme, TReqoreIntent } from '../../constants/theme';
 import { IReqoreIconName } from '../../types/icons';
 import { IReqoreButtonProps } from '../Button';
+import { TReqoreTabsContentPadding } from './content';
 import ReqoreTabsList from './list';
 
 export interface IReqoreTabsListItem extends Omit<IReqoreButtonProps, 'id'> {
@@ -26,6 +27,8 @@ export interface IReqoreTabsProps extends React.HTMLAttributes<HTMLDivElement> {
   fillParent?: boolean;
   vertical?: boolean;
   activeTabIntent?: TReqoreIntent;
+  padded?: boolean;
+  tabsPadding?: TReqoreTabsContentPadding;
   wrapTabNames?: boolean;
   flat?: boolean;
   size?: TSizes;
@@ -61,6 +64,8 @@ const ReqoreTabs = ({
   wrapTabNames,
   customTheme,
   intent,
+  padded,
+  tabsPadding,
   ...rest
 }: IReqoreTabsProps) => {
   const [_activeTab, setActiveTab] = useState<string | number>(activeTab || tabs[0].id);
@@ -84,6 +89,7 @@ const ReqoreTabs = ({
     >
       <ReqoreTabsList
         tabs={tabs}
+        padded={padded}
         flat={flat}
         fill={fill}
         size={size}
@@ -104,7 +110,11 @@ const ReqoreTabs = ({
         }}
       />
       {React.Children.map(children, (child) =>
-        child && child.props?.tabId === _activeTab ? child : null
+        child && child.props?.tabId === _activeTab
+          ? React.cloneElement(child, {
+              padded: child.props?.padded || tabsPadding,
+            })
+          : null
       )}
     </StyledTabs>
   );

--- a/src/components/Tabs/item.tsx
+++ b/src/components/Tabs/item.tsx
@@ -18,6 +18,7 @@ export interface IReqoreTabListItemProps extends IReqoreTabsListItem, IWithReqor
   wrapTabNames?: boolean;
   fill?: boolean;
   className?: string;
+  padded?: boolean;
 }
 
 export interface IReqoreTabListItemStyle extends IReqoreTabListItemProps {
@@ -27,7 +28,7 @@ export interface IReqoreTabListItemStyle extends IReqoreTabListItemProps {
 }
 
 export const StyledTabListItem = styled.div<IReqoreTabListItemStyle>`
-  ${({ disabled, vertical, size, fill }: IReqoreTabListItemStyle) => {
+  ${({ disabled, vertical, size, fill, padded }: IReqoreTabListItemStyle) => {
     return css`
       display: flex;
       flex-shrink: 0;
@@ -48,6 +49,16 @@ export const StyledTabListItem = styled.div<IReqoreTabListItemStyle>`
               border-top-right-radius: 0 !important;
               border-bottom-right-radius: 0 !important;
             }
+
+            ${padded === false &&
+            css`
+              &:first-child {
+                padding-top: 0;
+              }
+              &:last-child {
+                padding-bottom: 0;
+              }
+            `}
           `
         : css`
             ${StyledButton} {
@@ -59,6 +70,16 @@ export const StyledTabListItem = styled.div<IReqoreTabListItemStyle>`
             ${StyledButton}:last-child {
               border-bottom-right-radius: 0 !important;
             }
+
+            ${padded === false &&
+            css`
+              &:first-child {
+                padding-left: 0;
+              }
+              &:last-child {
+                padding-right: 0;
+              }
+            `}
           `}
 
       ${fill &&
@@ -109,6 +130,7 @@ const ReqoreTabsListItem = memo(
         flat = true,
         wrapTabNames,
         id,
+        padded,
         ...rest
       }: IReqoreTabListItemProps,
       ref
@@ -129,6 +151,7 @@ const ReqoreTabsListItem = memo(
           vertical={vertical}
           theme={theme}
           fill={fill}
+          padded={padded}
         >
           {label || icon ? (
             <ReqoreControlGroup stack size={size} fluid={fill || vertical}>

--- a/src/components/Tabs/list.tsx
+++ b/src/components/Tabs/list.tsx
@@ -162,6 +162,7 @@ const ReqoreTabsList = ({
   flat,
   size,
   intent,
+  padded,
   ...rest
 }: IReqoreTabsListProps) => {
   const [ref, { width }] = useMeasure();
@@ -211,6 +212,7 @@ const ReqoreTabsList = ({
                     vertical,
                     flat,
                     size,
+                    padded,
                     className: 'reqore-tabs-list-item-menu',
                   } as IReqoreTabListItemProps
                 }
@@ -279,6 +281,7 @@ const ReqoreTabsList = ({
                 fill={fill}
                 size={size}
                 flat={flat}
+                padded={padded}
                 activeIntent={activeTabIntent}
                 wrapTabNames={wrapTabNames}
                 {...item}

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -35,6 +35,7 @@ import ReqoreIcon from '../Icon';
 
 export interface IReqoreTagAction extends IWithReqoreTooltip, IReqoreDisabled, IReqoreIntent {
   icon: IReqoreIconName;
+  show?: boolean;
   onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
 }
 
@@ -331,28 +332,30 @@ const ReqoreTag = forwardRef<HTMLSpanElement, IReqoreTagProps>(
           </StyledTagContentWrapper>
         ) : null}
         {_size(actions)
-          ? actions.map((action, index) => (
-              <React.Fragment key={index}>
-                <ReqorePopover
-                  component={StyledButtonWrapper}
-                  componentProps={{
-                    size,
-                    color: getCustomColor(action.intent),
-                    className: 'reqore-tag-action',
-                    onClick: action.onClick,
-                    effect: rest.effect,
-                  }}
-                  {...(action.tooltip
-                    ? typeof action.tooltip === 'string'
-                      ? { tooltip: action.tooltip }
-                      : action.tooltip
-                    : {})}
-                  isReqoreComponent
-                >
-                  <ReqoreIcon icon={action.icon} size={size} />
-                </ReqorePopover>
-              </React.Fragment>
-            ))
+          ? actions
+              .filter((action) => action.show !== false)
+              .map((action, index) => (
+                <React.Fragment key={index}>
+                  <ReqorePopover
+                    component={StyledButtonWrapper}
+                    componentProps={{
+                      size,
+                      color: getCustomColor(action.intent),
+                      className: 'reqore-tag-action',
+                      onClick: action.onClick,
+                      effect: rest.effect,
+                    }}
+                    {...(action.tooltip
+                      ? typeof action.tooltip === 'string'
+                        ? { tooltip: action.tooltip }
+                        : action.tooltip
+                      : {})}
+                    isReqoreComponent
+                  >
+                    <ReqoreIcon icon={action.icon} size={size} />
+                  </ReqorePopover>
+                </React.Fragment>
+              ))
           : null}
         {onRemoveClick && !rest.disabled ? (
           <ReqorePopover

--- a/src/constants/sizes.ts
+++ b/src/constants/sizes.ts
@@ -37,19 +37,19 @@ export const HEADER_SIZE_TO_NUMBER = {
 };
 
 export const SIZE_TO_PX = {
-  tiny: 10,
-  small: 20,
+  tiny: 18,
+  small: 24,
   normal: 30,
   big: 40,
   huge: 50,
 };
 
 export const BADGE_SIZE_TO_PX = {
-  tiny: 10,
-  small: 18,
-  normal: 24,
-  big: 30,
-  huge: 36,
+  tiny: 14,
+  small: 20,
+  normal: 26,
+  big: 32,
+  huge: 38,
 };
 
 export const TABS_SIZE_TO_PX = {

--- a/src/containers/ReqoreProvider.tsx
+++ b/src/containers/ReqoreProvider.tsx
@@ -122,6 +122,7 @@ const ReqoreProvider: React.FC<IReqoreNotifications> = ({ children, options = {}
           isMobileOrTablet,
           getAndIncreaseZIndex,
           animations: options.animations || { buttons: true, dialogs: true },
+          tooltips: options.tooltips || { delay: 0 },
           closePopoversOnEscPress:
             'closePopoversOnEscPress' in options ? options.closePopoversOnEscPress : true,
         }}

--- a/src/containers/UIProvider.tsx
+++ b/src/containers/UIProvider.tsx
@@ -18,6 +18,13 @@ export interface IReqoreOptions {
     buttons?: boolean;
     dialogs?: boolean;
   };
+  tooltips?: {
+    /**
+     * Delay in ms before showing the tooltip
+     * @default 0
+     * */
+    delay?: number;
+  };
   closePopoversOnEscPress?: boolean;
 }
 export interface IReqoreUIProviderProps {

--- a/src/context/ReqoreContext.tsx
+++ b/src/context/ReqoreContext.tsx
@@ -12,6 +12,7 @@ export interface IReqoreContext {
   readonly isMobileOrTablet?: boolean;
   readonly getAndIncreaseZIndex?: () => number;
   readonly animations?: IReqoreOptions['animations'];
+  readonly tooltips?: IReqoreOptions['tooltips'];
   readonly closePopoversOnEscPress?: boolean;
 }
 

--- a/src/hooks/usePopover.tsx
+++ b/src/hooks/usePopover.tsx
@@ -11,6 +11,7 @@ import {
   IWithReqoreMinimal,
 } from '../types/global';
 import { IReqoreIconName } from '../types/icons';
+import { useReqore } from './useReqore';
 
 const startEvents = {
   hover: 'mouseenter',
@@ -77,6 +78,7 @@ const usePopover = ({
 }: IPopoverOptions): IPopoverControls => {
   const { addPopover, removePopover, updatePopover, popovers, isPopoverOpen } =
     useContext(PopoverContext);
+  const { tooltips } = useReqore();
   const { current }: MutableRefObject<string> = useRef(shortid.generate());
   let { current: timeout }: MutableRefObject<any> = useRef(0);
 
@@ -112,10 +114,10 @@ const usePopover = ({
         _removePopover?.();
       }
     } else if (show) {
-      if (delay) {
+      if (delay || tooltips.delay) {
         timeout = setTimeout(() => {
           openPopover();
-        }, delay);
+        }, delay || tooltips.delay);
       } else {
         openPopover();
       }

--- a/src/mock/collectionData.tsx
+++ b/src/mock/collectionData.tsx
@@ -104,6 +104,22 @@ export default [
       weight: 'thin',
       spaced: 2,
     },
+    expandedActions: [
+      {
+        label: 'Action 1',
+        id: 'action1',
+        icon: 'CapsuleFill',
+        onClick: () => alert('Action 1 clicked'),
+        position: 'left',
+      },
+      {
+        label: 'Action 2',
+        id: 'action2',
+        icon: 'CapsuleFill',
+        onClick: () => alert('Action 2 clicked'),
+        position: 'right',
+      },
+    ],
     expandedContent: (
       <>
         <ReqoreMessage intent='info'>Hello I am a custom content</ReqoreMessage>
@@ -191,6 +207,9 @@ export default [
   },
   {
     label: 'I have intent!',
+    transparent: true,
+    minimal: false,
+    flat: false,
     content: (
       <ReqoreP>
         'Well would you look at that. Lorem ipsum dolor{' '}
@@ -242,13 +261,14 @@ export default [
   {
     label: 'I have actions',
     content:
-      'Hello I am a test item content and I am very long so I will wrap to the next line and I will be very long',
+      'Hello I am a test item content and I am very long so I will wrap to the next line and I will be very long. Hello I am a test item content and I am very long so I will wrap to the next line and I will be very long. Hello I am a test item content and I am very long so I will wrap to the next line and I will be very long. Hello I am a test item content and I am very long so I will wrap to the next line and I will be very long. Hello I am a test item content and I am very long so I will wrap to the next line and I will be very long. Hello I am a test item content and I am very long so I will wrap to the next line and I will be very long',
     actions: [
       {
         label: 'Action 1',
         id: 'action1',
         icon: 'CapsuleFill',
         onClick: () => alert('Action 1 clicked'),
+        show: false,
       },
       {
         label: 'Action 2',

--- a/src/stories/ControlGroup/ControlGroup.stories.tsx
+++ b/src/stories/ControlGroup/ControlGroup.stories.tsx
@@ -9,7 +9,7 @@ import {
   ReqoreTag,
   ReqoreVerticalSpacer,
 } from '../../index';
-import { GapSizeArg, MinimalArg, SizeArg, argManager } from '../utils/args';
+import { argManager, GapSizeArg, MinimalArg, SizeArg } from '../utils/args';
 
 const { createArg } = argManager<IReqoreControlGroupProps>();
 
@@ -55,6 +55,7 @@ const Template: Story<IReqoreControlGroupProps> = (args: IReqoreControlGroupProp
           icon='PictureInPictureLine'
           flat={false}
           effect={{ gradient: { colors: { 0: 'success', 100: 'info:darken:1' } } }}
+          description="With a description, it's a bit longer than the button itself"
         >
           Non flat Button
         </ReqoreButton>
@@ -217,4 +218,15 @@ BigGapSize.args = {
 export const NoWrap = Template.bind({});
 NoWrap.args = {
   wrap: false,
+};
+
+export const HorizontalAlign = Template.bind({});
+HorizontalAlign.args = {
+  vertical: true,
+  horizontalAlign: 'center',
+};
+
+export const VerticalAlign = Template.bind({});
+VerticalAlign.args = {
+  verticalAlign: 'flex-end',
 };

--- a/src/stories/Icon/Icon.stories.tsx
+++ b/src/stories/Icon/Icon.stories.tsx
@@ -21,6 +21,7 @@ export const Icon: Story<IReqoreIconProps> = () => {
           color='#291133'
           effect={{ sepia: true }}
           margin='both'
+          tooltip={{ content: 'I have a tooltip', openOnMount: true }}
         />
         <ReqoreIcon
           icon='SignalTowerFill'

--- a/src/stories/Input/Input.stories.tsx
+++ b/src/stories/Input/Input.stories.tsx
@@ -2,13 +2,14 @@ import { Meta, Story } from '@storybook/react/types-6-0';
 import { useState } from 'react';
 import ReqoreInput, { IReqoreInputProps } from '../../components/Input';
 import { ReqoreControlGroup } from '../../index';
-import { FlatArg, IconArg, MinimalArg } from '../utils/args';
+import { FlatArg, IconArg, MinimalArg, SizeArg } from '../utils/args';
 
 export default {
   title: 'Components/Input',
   argTypes: {
     ...MinimalArg,
     ...FlatArg,
+    ...SizeArg,
     ...IconArg('icon', 'Icon', 'SearchLine'),
   },
 } as Meta<IReqoreInputProps>;

--- a/src/stories/Panel/Panel.stories.tsx
+++ b/src/stories/Panel/Panel.stories.tsx
@@ -1,8 +1,10 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { noop } from 'lodash';
+import { ReqoreColumns } from '../../components/Columns';
+import { ReqoreColumn } from '../../components/Columns/column';
 import ReqoreInput, { IReqoreInputProps } from '../../components/Input';
 import { IReqorePanelProps, ReqorePanel } from '../../components/Panel';
-import { FlatArg, IconArg, IntentArg, argManager } from '../utils/args';
+import { argManager, FlatArg, IconArg, IntentArg } from '../utils/args';
 
 const { createArg } = argManager<IReqorePanelProps>();
 
@@ -64,6 +66,23 @@ export default {
 } as Meta<IReqorePanelProps>;
 
 const Template: Story<IReqorePanelProps> = (args: IReqorePanelProps) => {
+  if (args.fluid) {
+    return (
+      <ReqoreColumns columnsGap='10px'>
+        <ReqoreColumn>
+          <ReqorePanel {...args} badge='Fluid'>
+            This is a fluid panel
+          </ReqorePanel>
+        </ReqoreColumn>
+        <ReqoreColumn>
+          <ReqorePanel {...args} fluid={false} badge='Not Fluid'>
+            This is not a fluid panel
+          </ReqorePanel>
+        </ReqoreColumn>
+      </ReqoreColumns>
+    );
+  }
+
   return (
     <ReqorePanel
       {...args}
@@ -167,10 +186,29 @@ Transparent.args = {
   transparent: true,
 };
 
+export const Intent: Story<IReqorePanelProps> = Template.bind({});
+Intent.args = {
+  intent: 'success',
+  iconColor: 'success:lighten:2',
+  transparent: true,
+  flat: true,
+};
+
 export const Minimal: Story<IReqorePanelProps> = Template.bind({});
 Minimal.args = {
   minimal: true,
   flat: true,
+};
+
+export const TransparentFlat: Story<IReqorePanelProps> = Template.bind({});
+TransparentFlat.args = {
+  transparent: true,
+  flat: true,
+};
+
+export const Fluid: Story<IReqorePanelProps> = Template.bind({});
+Fluid.args = {
+  fluid: true,
 };
 
 export const WithEffect: Story<IReqorePanelProps> = Template.bind({});

--- a/src/stories/Tabs/Tabs.stories.tsx
+++ b/src/stories/Tabs/Tabs.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { IReqoreTabsProps } from '../../components/Tabs';
-import { ReqoreTabs, ReqoreTabsContent } from '../../index';
+import { TReqoreTabsContentPadding } from '../../components/Tabs/content';
+import { ReqoreH3, ReqoreTabs, ReqoreTabsContent } from '../../index';
 import { IntentArg, SizeArg, argManager } from '../utils/args';
 
 const tabs = [
@@ -99,7 +100,7 @@ const tabs = [
   },
 ] as IReqoreTabsProps['tabs'];
 
-const { createArg } = argManager<IReqoreTabsProps>();
+const { createArg } = argManager<IReqoreTabsProps & { tabPadding: TReqoreTabsContentPadding }>();
 
 export default {
   title: 'Components/Tabs',
@@ -137,25 +138,25 @@ export default {
       description: 'If the tabs should be vertical',
     }),
   },
-} as Meta<IReqoreTabsProps>;
+} as Meta<IReqoreTabsProps & { tabPadding: TReqoreTabsContentPadding }>;
 
-const Template: Story<IReqoreTabsProps> = (args) => {
+const Template: Story<IReqoreTabsProps & { tabPadding: TReqoreTabsContentPadding }> = (args) => {
   return (
     <ReqoreTabs {...args} tabs={tabs}>
       <ReqoreTabsContent tabId='tab1'>
-        <h3>Tab 1</h3>
+        <ReqoreH3>Tab 1</ReqoreH3>
       </ReqoreTabsContent>
       <ReqoreTabsContent tabId='tab2'>
-        <h3>Tab 2</h3>
+        <ReqoreH3>Tab 2</ReqoreH3>
       </ReqoreTabsContent>
-      <ReqoreTabsContent tabId={3}>
-        <h3>Tab 3</h3>
+      <ReqoreTabsContent tabId={3} padded='vertical'>
+        <ReqoreH3>Tab 3</ReqoreH3>
       </ReqoreTabsContent>
       <ReqoreTabsContent tabId='tab4'>
-        <h3>Tab 4</h3>
+        <ReqoreH3>Tab 4</ReqoreH3>
       </ReqoreTabsContent>
       <ReqoreTabsContent tabId='tab5'>
-        <h3>Tab 5</h3>
+        <ReqoreH3>Tab 5</ReqoreH3>
       </ReqoreTabsContent>
       <ReqoreTabsContent tabId='tab6'>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur vitae nisi ligula. Proin
@@ -216,13 +217,13 @@ const Template: Story<IReqoreTabsProps> = (args) => {
         Praesent vitae bibendum mauris, eu blandit dui.
       </ReqoreTabsContent>
       <ReqoreTabsContent tabId='tab7'>
-        <h3>Tab 7</h3>
+        <ReqoreH3>Tab 7</ReqoreH3>
       </ReqoreTabsContent>
       <ReqoreTabsContent tabId='tab8'>
-        <h3>Tab 8</h3>
+        <ReqoreH3>Tab 8</ReqoreH3>
       </ReqoreTabsContent>
       <ReqoreTabsContent tabId='tab9'>
-        <h3>Tab 9</h3>
+        <ReqoreH3>Tab 9</ReqoreH3>
       </ReqoreTabsContent>
     </ReqoreTabs>
   );
@@ -244,10 +245,21 @@ NotFlat.args = {
   flat: false,
 };
 
+export const NoTabsPadding = Template.bind({});
+NoTabsPadding.args = {
+  padded: false,
+};
+
 export const Vertical = Template.bind({});
 Vertical.args = {
   vertical: true,
   fillParent: true,
+};
+
+export const VerticalNoTabsPadding = Template.bind({});
+VerticalNoTabsPadding.args = {
+  padded: false,
+  vertical: true,
 };
 
 export const VerticalWithWrapping = Template.bind({});
@@ -260,7 +272,11 @@ VerticalWithWrapping.args = {
 export const VerticalCustomWidth = Template.bind({});
 VerticalCustomWidth.args = {
   vertical: true,
-  fill: true,
   fillParent: true,
   width: '300px',
+};
+
+export const CustomTabsPadding = Template.bind({});
+CustomTabsPadding.args = {
+  tabsPadding: 'none',
 };

--- a/src/stories/Tag/Tag.stories.tsx
+++ b/src/stories/Tag/Tag.stories.tsx
@@ -3,7 +3,7 @@ import { noop } from 'lodash';
 import { IReqoreTagProps } from '../../components/Tag';
 import { IReqoreTagGroup } from '../../components/Tag/group';
 import { ReqoreTag, ReqoreTagGroup } from '../../index';
-import { SizeArg, argManager } from '../utils/args';
+import { argManager, SizeArg } from '../utils/args';
 
 const { createArg } = argManager<IReqoreTagGroup & IReqoreTagProps>();
 
@@ -95,6 +95,17 @@ const Template: Story<IReqoreTagGroup & IReqoreTagProps> = ({ columns, ...args }
         tooltip='I am wiiiiiiide'
         actions={[
           {
+            icon: 'ErrorWarningLine',
+            onClick: noop,
+            intent: 'info',
+            tooltip: {
+              content: 'IF YOU CAN SEE ME ITS A BUG!!! I HAVE show: false',
+              openOnMount: true,
+              intent: 'danger',
+            },
+            show: false,
+          },
+          {
             icon: '24HoursFill',
             onClick: noop,
             disabled: true,
@@ -105,7 +116,6 @@ const Template: Story<IReqoreTagGroup & IReqoreTagProps> = ({ columns, ...args }
             icon: 'SpyFill',
             onClick: noop,
             intent: 'success',
-            tooltip: { content: 'Hm, another tooltip', openOnMount: true },
           },
         ]}
       />

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -126,6 +126,20 @@ export interface IWithReqoreFlat {
   flat?: boolean;
 }
 
+export interface IWithReqoreFluid {
+  /**
+   * If true, the component will fill the parent container horizontally
+   * @default false
+   * @type boolean
+   * @example
+   * <ReqoreInput fluid />
+   * <ReqoreInput fluid={true} />
+   * <ReqoreInput fluid={false} />
+   *
+   */
+  fluid?: boolean;
+}
+
 export interface IWithReqoreMinimal {
   /**
    * If true, the component will be minimal


### PR DESCRIPTION
Closes #228

Removable padding from ReqoreTabsContent, remove padding from 1st and last tab
 Check ReqorePanel 10px padding bottom
 Add show property to ReqoreTag actions, same as ReqorePanel actions
 ReqoreIcon doesn't support tooltip
 display: none !important when ReqorePanel is collapased and unMountContentOnCollapse is false
 Increase sizes (small to 24px instead of 20px)
 Add global tooltip delay
 Why do we set align-items: stretch on ReqoreControlGroup ?
 Add show property to actions on ReqoreCollection item
 Support Icon, flat on ReqoreCollection
 Add users passed style to ReqorePanel style inside ReqoreCollection
 Support fluid on ReqorePanel and ReqoreCollection
 Allow setting of the empty message on ReqoreCollection