### PR TITLE
Table fixes:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Table/cell.tsx
+++ b/src/components/Table/cell.tsx
@@ -13,6 +13,7 @@ export interface IReqoreTableBodyCellProps
   extends Partial<IReqoreTableColumn>,
     React.HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
+  padded?: IReqoreTableColumn['cell']['padded'];
 }
 
 export const StyledTableCell = styled.div<IReqoreTableCellStyle>`
@@ -36,6 +37,7 @@ export const StyledTableCell = styled.div<IReqoreTableCellStyle>`
     selectedIntent,
     disabled,
     hovered,
+    padded,
   }: IReqoreTableCellStyle) => {
     const getBackgroundColor = (): TReqoreColor => {
       let color = theme.main;
@@ -76,7 +78,8 @@ export const StyledTableCell = styled.div<IReqoreTableCellStyle>`
       border-bottom: ${!flat ? '1px solid ' : undefined};
 
       height: 100%;
-      padding: 0 10px;
+      padding: ${!padded || padded === 'both' || padded === 'vertical' ? 0 : undefined}
+        ${!padded || padded === 'both' || padded === 'horizontal' ? '10px' : undefined};
       font-size: ${TEXT_FROM_SIZE[size]}px;
       background-color: ${backgroundColor === 'transparent'
         ? 'transparent'

--- a/src/components/Table/headerCell.tsx
+++ b/src/components/Table/headerCell.tsx
@@ -18,6 +18,7 @@ export interface IReqoreTableHeaderCellProps
   sortData?: IReqoreTableSort;
   onColumnsUpdate?: TColumnsUpdater;
   onFilterChange?: (dataId: string, filter: string) => void;
+  actions?: IReqoreTableColumn['header']['actions'];
 }
 
 export interface IReqoreTableHeaderStyle {
@@ -58,11 +59,13 @@ export const ReqoreTableHeaderCell = ({
   filterable,
   hideable = true,
   filter,
+  size,
   onFilterChange,
+  actions,
   ...rest
 }: IReqoreTableHeaderCellProps) => {
   const items = useMemo(() => {
-    const _items: IReqoreDropdownItem[] = [];
+    let _items: IReqoreDropdownItem[] = [];
 
     if (resizable || hideable) {
       _items.push({
@@ -85,11 +88,16 @@ export const ReqoreTableHeaderCell = ({
         _items.push({
           label: 'Hide column',
           icon: 'EyeCloseLine',
+          className: 'reqore-table-header-hide',
           onClick: () => {
             onColumnsUpdate?.(dataId, 'show', false);
           },
         });
       }
+    }
+
+    if (actions) {
+      _items = [..._items, { divider: true, label: 'Other' }, ...actions];
     }
 
     return _items;
@@ -119,6 +127,7 @@ export const ReqoreTableHeaderCell = ({
       <ReqoreControlGroup fluid stack rounded={false} fill style={{ height: '100%' }}>
         <ReqoreButton
           {...rest}
+          size={size}
           readOnly={!sortable && !onClick}
           className={`${className || ''} reqore-table-header-cell`}
           rounded={false}
@@ -143,6 +152,7 @@ export const ReqoreTableHeaderCell = ({
             icon='MoreLine'
             className='reqore-table-header-cell-options'
             fixed
+            size={size}
             rounded={false}
             intent={filter ? 'info' : undefined}
             filterable={filterable}

--- a/src/components/Table/helpers.ts
+++ b/src/components/Table/helpers.ts
@@ -175,6 +175,7 @@ export const getOnlyShownColumns = (columns: IReqoreTableColumn[]): IReqoreTable
 
 export const prepareColumns = (
   columns: IReqoreTableColumn[],
+  columnModifiers: { [key: string]: { [key: string]: any } },
   size: TSizes = 'normal'
 ): IReqoreTableColumn[] => {
   // We need to set the width of each column
@@ -182,7 +183,10 @@ export const prepareColumns = (
     if (column.header.columns) {
       return {
         ...column,
-        header: { ...column.header, columns: prepareColumns(column.header.columns) },
+        header: {
+          ...column.header,
+          columns: prepareColumns(column.header.columns, columnModifiers, size),
+        },
       };
     }
 
@@ -199,6 +203,7 @@ export const prepareColumns = (
     return {
       ...column,
       width: newWidth,
+      ...(columnModifiers?.[column.dataId] || {}),
     };
   });
 };

--- a/src/components/Table/row.tsx
+++ b/src/components/Table/row.tsx
@@ -62,8 +62,8 @@ export const StyledTableRow = styled.div<IReqoreTableRowStyle>`
 
 export interface IReqoreTableCellStyle {
   width?: number;
-  grow?: number;
   theme?: IReqoreTheme;
+  grow: 1 | 2 | 3 | 4;
   align?: 'center' | 'left' | 'right';
   intent?: TReqoreIntent;
   interactive?: boolean;
@@ -76,6 +76,7 @@ export interface IReqoreTableCellStyle {
   selectedIntent?: TReqoreIntent;
   even?: boolean;
   striped?: boolean;
+  padded?: IReqoreTableColumn['cell']['padded'];
 }
 
 const ReqoreTableRow = ({
@@ -110,7 +111,7 @@ const ReqoreTableRow = ({
     if (isFunction(content)) {
       const Content = content;
 
-      return <Content {...data} />;
+      return <Content {...data} _size={size} _dataId={dataId} />;
     }
 
     if (isString(content)) {
@@ -181,6 +182,7 @@ const ReqoreTableRow = ({
                 align,
                 size,
                 striped,
+                padded: cell?.padded,
                 disabled: data[index]._disabled,
                 selected: !!isSelected,
                 selectedIntent: selectedRowIntent,

--- a/src/stories/Table/Table.stories.tsx
+++ b/src/stories/Table/Table.stories.tsx
@@ -3,7 +3,15 @@ import { StyledEffect } from '../../components/Effect';
 import { IReqoreTableColumn, IReqoreTableProps } from '../../components/Table';
 import { IReqoreCustomTableBodyCellProps } from '../../components/Table/cell';
 import { IReqoreCustomHeaderCellProps } from '../../components/Table/header';
-import { ReqoreH3, ReqoreH4, ReqoreIcon, ReqoreP, ReqoreTable, ReqoreTag } from '../../index';
+import {
+  ReqoreH3,
+  ReqoreH4,
+  ReqoreIcon,
+  ReqoreInput,
+  ReqoreP,
+  ReqoreTable,
+  ReqoreTag,
+} from '../../index';
 import tableData from '../../mock/tableData';
 import { CustomIntentArg, FlatArg, IntentArg, SizeArg, argManager } from '../utils/args';
 
@@ -40,6 +48,12 @@ const defaultColumns: IReqoreTableColumn[] = [
                 },
               },
             },
+          },
+          cell: {
+            padded: 'none',
+            content: ({ _size, firstName }) => (
+              <ReqoreInput icon='PriceTag2Fill' size={_size} value={firstName} />
+            ),
           },
           width: 150,
           grow: 2,
@@ -80,6 +94,12 @@ const defaultColumns: IReqoreTableColumn[] = [
       label: 'Really long age header',
       icon: 'User4Line',
       tooltip: 'Custom age tooltip',
+      actions: [
+        {
+          label: 'Do something',
+          icon: 'EBike2Fill',
+        },
+      ],
     },
     width: 100,
     align: 'center',


### PR DESCRIPTION
- Columns are no longer reset when they are updated from props (test included)
- `size` is now passed to `content` in `cell`
- new `onSelectClick` prop
- Added `Reset to default` on the table to reset all columns to default state
- `cell` can now have no padding
- `header` can now have custom actions