### PR TITLE
feat: add sortByGroupFirst prop to ReqoreCollection

### DIFF
--- a/__tests__/collection.test.tsx
+++ b/__tests__/collection.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils';
 import { ReqoreCollection, ReqoreLayoutContent, ReqoreUIProvider } from '../src';
+import { IReqoreCollectionItemProps } from '../src/components/Collection/item';
 import items, { bigCollection } from '../src/mock/collectionData';
 
 test('Renders basic <Collection /> properly', () => {
@@ -240,4 +241,77 @@ test('<Collection /> has 2 paging controls', () => {
   expect(document.querySelectorAll('.reqore-pagination-wrapper').length).toBe(2);
   expect(document.querySelectorAll('.reqore-button').length).toBe(11);
   expect(document.querySelectorAll('.reqore-collection-item').length).toBe(10);
+});
+
+test('<Collection /> sortByGroupFirst=false sorts by custom field before group', () => {
+  const groupedItems: IReqoreCollectionItemProps[] = [
+    {
+      label: 'Zendesk Exact Match',
+      groups: ['Zendesk'],
+      metadata: { relevance: 0 },
+    },
+    {
+      label: 'AWS Partial Match',
+      groups: ['AWS'],
+      metadata: { relevance: 1 },
+    },
+    {
+      label: 'AWS Exact Match',
+      groups: ['AWS'],
+      metadata: { relevance: 0 },
+    },
+    {
+      label: 'Zendesk Weak Match',
+      groups: ['Zendesk'],
+      metadata: { relevance: 2 },
+    },
+  ];
+
+  // With sortByGroupFirst=true (default): items grouped by group first
+  const { unmount } = render(
+    <ReqoreUIProvider>
+      <ReqoreLayoutContent>
+        <ReqoreCollection
+          items={groupedItems}
+          defaultSortBy='relevance'
+          sortKeys={{ relevance: 'Relevance' }}
+        />
+      </ReqoreLayoutContent>
+    </ReqoreUIProvider>
+  );
+
+  const defaultLabels = Array.from(
+    document.querySelectorAll('.reqore-collection-item .reqore-panel-title')
+  ).map((el) => el.textContent);
+
+  // Group sort first: AWS items come before Zendesk items (A < Z)
+  expect(defaultLabels[0]).toBe('AWS Exact Match');
+  expect(defaultLabels[1]).toBe('AWS Partial Match');
+
+  unmount();
+
+  // With sortByGroupFirst=false: items sorted by relevance first
+  render(
+    <ReqoreUIProvider>
+      <ReqoreLayoutContent>
+        <ReqoreCollection
+          items={groupedItems}
+          sortByGroupFirst={false}
+          defaultSortBy='relevance'
+          sortKeys={{ relevance: 'Relevance' }}
+        />
+      </ReqoreLayoutContent>
+    </ReqoreUIProvider>
+  );
+
+  const relevanceLabels = Array.from(
+    document.querySelectorAll('.reqore-collection-item .reqore-panel-title')
+  ).map((el) => el.textContent);
+
+  // Relevance sort first: relevance=0 items before relevance=1 items
+  // Items are rendered flat (not re-grouped), preserving relevance order
+  expect(relevanceLabels[0]).toBe('Zendesk Exact Match');
+  expect(relevanceLabels[1]).toBe('AWS Exact Match');
+  expect(relevanceLabels[2]).toBe('AWS Partial Match');
+  expect(relevanceLabels[3]).toBe('Zendesk Weak Match');
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.62.1",
+  "version": "0.62.2",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Collection/index.tsx
+++ b/src/components/Collection/index.tsx
@@ -25,6 +25,21 @@ import { ReqoreVerticalSpacer } from '../Spacer';
 import { getZoomActions, sizeToZoom, sortTableData, zoomToSize } from '../Table/helpers';
 import { IReqoreCollectionItemProps, ReqoreCollectionItem } from './item';
 
+const CollectionGroupHeader = memo(({ name }: { name: string }) => (
+  <ReqoreP
+    style={{ gridColumn: '1 / -1' }}
+    effect={{
+      opacity: 0.8,
+      uppercase: true,
+      weight: 'bold',
+      textSize: 'small',
+      spaced: 1,
+    }}
+  >
+    {name}
+  </ReqoreP>
+));
+
 export type TReqoreCollectionActions = (IReqorePanelAction & { position?: 'left' | 'right' })[];
 export interface IReqoreCollectionProps
   extends IReqoreComponent,
@@ -50,6 +65,7 @@ export interface IReqoreCollectionProps
   defaultSortBy?: string;
 
   sortKeys?: Record<string, string>;
+  sortByGroupFirst?: boolean;
 
   filterable?: boolean;
   sortable?: boolean;
@@ -132,6 +148,7 @@ export const ReqoreCollection = memo(
     skeleton,
 
     sortKeys = {},
+    sortByGroupFirst = true,
 
     onQueryChange,
     contentRenderer = (children, _items, searchInput) => (
@@ -188,33 +205,25 @@ export const ReqoreCollection = memo(
         return items;
       }
 
+      const sortConfig = sortByGroupFirst
+        ? { by: 'group', thenBy: _sortBy, direction: sort }
+        : { by: _sortBy, thenBy: 'group', direction: sort };
+
       if (showSelectedFirst) {
         // Filter out the selected items
         const selectedItems = items.filter((item) => item.selected);
         // Filter out the unselected items
         const unselectedItems = items.filter((item) => !item.selected);
         // Sort the selected items
-        const sortedSelectedItems = sortTableData(selectedItems, {
-          by: 'group',
-          thenBy: _sortBy,
-          direction: sort,
-        });
+        const sortedSelectedItems = sortTableData(selectedItems, sortConfig);
         // Sort the unselected items
-        const sortedUnselectedItems = sortTableData(unselectedItems, {
-          by: 'group',
-          thenBy: _sortBy,
-          direction: sort,
-        });
+        const sortedUnselectedItems = sortTableData(unselectedItems, sortConfig);
 
         return [...sortedSelectedItems, ...sortedUnselectedItems];
       }
 
-      return sortTableData(items, {
-        by: 'group',
-        thenBy: _sortBy,
-        direction: sort,
-      });
-    }, [items, sort, sortBy, showSelectedFirst, sortable]);
+      return sortTableData(items, sortConfig);
+    }, [items, sort, sortBy, showSelectedFirst, sortable, sortByGroupFirst]);
 
     const filteredItems: IReqoreCollectionItemProps[] = useMemo(() => {
       if (!filterable || query === '') {
@@ -387,11 +396,51 @@ export const ReqoreCollection = memo(
                 className='reqore-collection-content'
               >
                 {(() => {
+                  const pagedItems = applyPaging(filteredItems);
+
+                  // When sortByGroupFirst is false, render items in flat
+                  // sorted order with inline group headers when the group
+                  // changes, preserving the primary sort field order
+                  if (!sortByGroupFirst) {
+                    let lastGroup: string | undefined;
+
+                    return pagedItems.map((item, index) => {
+                      const group =
+                        item.groups && !paging ? item.groups[0] : undefined;
+                      const showHeader =
+                        group && group !== 'Ungrouped' && group !== lastGroup;
+
+                      if (group) {
+                        lastGroup = group;
+                      }
+
+                      return (
+                        <React.Fragment key={index}>
+                          {showHeader && (
+                            <CollectionGroupHeader name={group} />
+                          )}
+                          <ReqoreErrorBoundary {...errorBoundaryOptions}>
+                            <ReqoreCollectionItem
+                              size={zoomToSize[zoom]}
+                              responsiveTitle={false}
+                              {...item}
+                              icon={
+                                item.icon ||
+                                (item.selected ? selectedIcon : undefined)
+                              }
+                              rounded={!stacked}
+                              maxContentHeight={maxItemHeight}
+                            />
+                          </ReqoreErrorBoundary>
+                        </React.Fragment>
+                      );
+                    });
+                  }
+
                   // Group items by their 'groups' property
                   // Groups is a list of strings, so an item can be in multiple groups
                   // Sort the groups based on defaultSort
-
-                  const grouped = applyPaging(filteredItems).reduce((acc, item) => {
+                  const grouped = pagedItems.reduce((acc, item) => {
                     const groups = item.groups && !paging ? item.groups : ['Ungrouped'];
 
                     groups.forEach((group) => {
@@ -432,18 +481,7 @@ export const ReqoreCollection = memo(
                   return Object.entries(orderedGrouped).map(([groupName, groupItems]) => (
                     <React.Fragment key={groupName}>
                       {groupName !== 'Ungrouped' && (
-                        <ReqoreP
-                          style={{ gridColumn: '1 / -1' }}
-                          effect={{
-                            opacity: 0.8,
-                            uppercase: true,
-                            weight: 'bold',
-                            textSize: 'small',
-                            spaced: 1,
-                          }}
-                        >
-                          {groupName}
-                        </ReqoreP>
+                        <CollectionGroupHeader name={groupName} />
                       )}
                       {groupItems.map((item, index) => (
                         <ReqoreErrorBoundary {...errorBoundaryOptions} key={index}>

--- a/src/stories/Collection/Collection.stories.tsx
+++ b/src/stories/Collection/Collection.stories.tsx
@@ -431,6 +431,82 @@ export const WithGroups: Story = {
   },
 };
 
+export const SortByRelevanceAcrossGroups: Story = {
+  args: {
+    label: 'Search Results (sorted by relevance, not group)',
+    sortByGroupFirst: false,
+    defaultSortBy: 'relevance',
+    defaultSort: 'asc',
+    sortKeys: {
+      relevance: 'Relevance',
+    },
+    items: [
+      {
+        label: 'Zendesk: Create Ticket',
+        groups: ['Zendesk'],
+        badge: 'Exact',
+        intent: 'success',
+        content: 'Creates a new support ticket in Zendesk',
+        metadata: { relevance: 0 },
+      },
+      {
+        label: 'AWS: Launch Instance',
+        groups: ['AWS'],
+        badge: 'Partial',
+        content: 'Launch a new EC2 instance in AWS',
+        metadata: { relevance: 1 },
+      },
+      {
+        label: 'AWS: S3 Upload',
+        groups: ['AWS'],
+        badge: 'Exact',
+        intent: 'success',
+        content: 'Upload a file to an S3 bucket',
+        metadata: { relevance: 0 },
+      },
+      {
+        label: 'Slack: Send Message',
+        groups: ['Slack'],
+        badge: 'Weak',
+        intent: 'warning',
+        content: 'Send a message to a Slack channel',
+        metadata: { relevance: 2 },
+      },
+      {
+        label: 'Slack: Create Channel',
+        groups: ['Slack'],
+        badge: 'Partial',
+        content: 'Create a new Slack channel',
+        metadata: { relevance: 1 },
+      },
+      {
+        label: 'Zendesk: Update Ticket',
+        groups: ['Zendesk'],
+        badge: 'Weak',
+        intent: 'warning',
+        content: 'Update an existing support ticket',
+        metadata: { relevance: 2 },
+      },
+      {
+        label: 'Discord: Post Announcement',
+        groups: ['Discord'],
+        badge: 'Exact',
+        intent: 'success',
+        content: 'Post an announcement to a Discord channel',
+        metadata: { relevance: 0 },
+      },
+      {
+        label: 'Discord: Ban User',
+        groups: ['Discord'],
+        badge: 'Weak',
+        intent: 'warning',
+        content: 'Ban a user from the Discord server',
+        metadata: { relevance: 2 },
+      },
+    ],
+  },
+};
+
 export const ItemIsInMultipleGroups: Story = {
   args: {
     items: [


### PR DESCRIPTION
## Summary

- Adds `sortByGroupFirst` prop (default: `true`) to `ReqoreCollection` that controls whether group sorting takes priority over the user's chosen sort field
- When `sortByGroupFirst={false}`, items are sorted by the selected `sortBy` field first (e.g., search relevance) and rendered in flat order with inline group headers — no longer re-grouped alphabetically
- Includes unit test and Storybook story (`SortByRelevanceAcrossGroups`) demonstrating the search relevance use case

Closes #514

## Test plan

- [x] All 344 existing tests pass
- [x] New test verifies items are sorted by relevance across groups with `sortByGroupFirst={false}`
- [x] `yarn precheck` passes (lint + test + build)
- [ ] Verify `SortByRelevanceAcrossGroups` story renders items by relevance with inline group headers
- [ ] Verify default behavior (`sortByGroupFirst={true}`) is unchanged in existing stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)