### PR TITLE
feat(Dropdown): document-level keyboard navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.63.17",
+  "version": "0.63.18",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -47,6 +47,14 @@ export interface IReqoreDropdownProps
   readOnlyOnEmpty?: boolean;
   // Whether keyboard navigation is enabled (arrow keys, enter, etc.)
   keyboardNavigation?: boolean;
+  /** Callback that receives keyboard controls, allowing external components
+   *  (e.g., a text input) to forward arrow/enter key events to the dropdown list.
+   *  This enables the aria-activedescendant pattern where focus stays on the input
+   *  while arrow keys navigate the dropdown. */
+  passKeyHandler?: IReqoreDropdownListProps['passKeyHandler'];
+  /** Unique ID for the dropdown list, used for aria-activedescendant support.
+   *  When set, each dropdown item gets an id of `${listId}-option-${index}`. */
+  listId?: string;
 
   popoverId?: string;
 }
@@ -127,6 +135,8 @@ function ReqoreDropdown<T = IReqoreButtonProps>({
   showCaret = true,
   readOnlyOnEmpty,
   keyboardNavigation = true,
+  passKeyHandler,
+  listId,
   onBeforeClose,
   onBeforeOpen,
   popoverId,
@@ -198,6 +208,8 @@ function ReqoreDropdown<T = IReqoreButtonProps>({
         customTheme={listCustomTheme}
         intent={listIntent}
         keyboardNavigation={keyboardNavigation}
+        passKeyHandler={passKeyHandler}
+        listId={listId}
         _onNavigateToLevel={handleNavigateToLevel}
         selectedItems={selectedItems}
         onSelectedItemsChange={setSelectedItems}

--- a/src/components/Dropdown/list.tsx
+++ b/src/components/Dropdown/list.tsx
@@ -42,6 +42,15 @@ export interface IReqoreDropdownItem<Metadata extends Record<string, any> = Reco
 export type TReqoreDropdownItem = IReqoreDropdownItem;
 export type TReqoreDropdownItems = TReqoreDropdownItem[];
 
+export type TDropdownKeyHandler = (event: React.KeyboardEvent | KeyboardEvent) => void;
+
+export interface IDropdownKeyboardControls {
+  /** Forward keyboard events (ArrowUp/Down, Enter) to the dropdown list. */
+  handleKeyDown: TDropdownKeyHandler;
+  /** The DOM id of the currently highlighted item, for aria-activedescendant. Null when nothing is highlighted. */
+  focusedItemId: string | null;
+}
+
 export interface IReqoreDropdownListProps
   extends IReqoreComponent,
     Pick<IReqoreDropdownProps, 'customElements'>,
@@ -66,6 +75,14 @@ export interface IReqoreDropdownListProps
   labels?: (IReqoreTagProps & { _levelIndex?: number })[];
 
   keyboardNavigation?: boolean;
+
+  /** Callback that receives keyboard controls, allowing external components
+   *  to forward arrow key events to the dropdown (aria-activedescendant pattern).
+   *  Called on every render with updated focusedItemId. */
+  passKeyHandler?: (controls: IDropdownKeyboardControls) => void;
+
+  /** Unique ID prefix for dropdown items, used for aria-activedescendant support. */
+  listId?: string;
 
   _onBackClick?: () => void;
   _onNavigateToLevel?: (level: number) => void;
@@ -95,6 +112,8 @@ const ReqoreDropdownList = memo(
     customTheme,
     intent,
     keyboardNavigation = true,
+    passKeyHandler,
+    listId,
 
     labels = [],
     _onBackClick,
@@ -239,8 +258,8 @@ const ReqoreDropdownList = memo(
     );
 
     // Handle keyboard navigation
-    const handleKeyDown = useCallback(
-      (event: React.KeyboardEvent<HTMLInputElement | HTMLDivElement>) => {
+    const handleKeyDown: TDropdownKeyHandler = useCallback(
+      (event: React.KeyboardEvent | KeyboardEvent) => {
         if (!keyboardNavigation) {
           return;
         }
@@ -292,6 +311,47 @@ const ReqoreDropdownList = memo(
         handleSelectItemAtLevel,
       ]
     );
+
+    // Compute the focused item's DOM id for aria-activedescendant
+    const focusedItemDomId = useMemo(() => {
+      if (focusedItemIndex === null || !listId) return null;
+      return `${listId}-option-${focusedItemIndex}`;
+    }, [focusedItemIndex, listId]);
+
+    // Register document-level keyboard listener so arrow keys work
+    // regardless of which element has focus (button, external input, etc.)
+    // Skip if the event target is already inside the dropdown (handled by input/menu onKeyDown)
+    useEffect(() => {
+      if (!keyboardNavigation) {
+        return () => {};
+      }
+
+      const listener = (event: KeyboardEvent) => {
+        const key = event.key;
+        if (key !== 'ArrowDown' && key !== 'ArrowUp' && key !== 'Enter' &&
+            key !== 'ArrowRight' && key !== 'ArrowLeft') {
+          return;
+        }
+
+        // Don't intercept if the event target is inside the dropdown's own elements
+        // (the filter input or menu already handle these via their onKeyDown)
+        if (menuRef && (event.target as HTMLElement)?.closest?.('.reqore-popover-content')) {
+          return;
+        }
+
+        handleKeyDown(event);
+      };
+
+      document.addEventListener('keydown', listener);
+      return () => document.removeEventListener('keydown', listener);
+    }, [keyboardNavigation, handleKeyDown, menuRef]);
+
+    // Expose keyboard controls to external components (aria-activedescendant pattern)
+    useEffect(() => {
+      if (passKeyHandler && keyboardNavigation) {
+        passKeyHandler({ handleKeyDown, focusedItemId: focusedItemDomId });
+      }
+    }, [passKeyHandler, handleKeyDown, keyboardNavigation, focusedItemDomId]);
 
     const getAction = useCallback(
       (item: TReqoreDropdownItem, position: 'left' | 'right') => {
@@ -485,6 +545,7 @@ const ReqoreDropdownList = memo(
                     ) : (
                       <ReqoreDropdownItem
                         key={item.label || item.value || index}
+                        id={listId ? `${listId}-option-${itemSelectableIndex}` : undefined}
                         rightIcon={
                           'items' in item && size(item.items) ? 'ArrowRightSLine' : item.rightIcon
                         }

--- a/src/components/RichTextEditor/index.tsx
+++ b/src/components/RichTextEditor/index.tsx
@@ -15,7 +15,7 @@ import { IReqoreDropdownProps } from '../Dropdown';
 import { IReqoreDropdownItemProps } from '../Dropdown/item';
 import { IReqorePanelAction, IReqorePanelProps } from '../Panel';
 import { ReqoreP } from '../Paragraph';
-import { ReqoreSpan } from '../Span';
+import { IReqoreSpanProps, ReqoreSpan } from '../Span';
 import ReqoreTag, { IReqoreTagProps } from '../Tag';
 import { IReqoreTextareaProps } from '../Textarea';
 
@@ -59,6 +59,7 @@ export interface IReqoreRichTextEditorProps
   tagsListProps?: Omit<IReqoreDropdownProps, 'items'> & EditableProps;
   panelProps?: IReqorePanelProps;
 
+  placeholderProps?: IReqoreSpanProps;
   actions?: {
     styling?: boolean;
     undo?: boolean;
@@ -144,8 +145,31 @@ const Leaf = ({ attributes, children, leaf }: RenderLeafProps) => {
   );
 };
 
-export const DefaultElement = (props: RenderElementProps) => (
-  <ReqoreP {...props.attributes}>{props.children}</ReqoreP>
+export const DefaultElement = (
+  props: RenderElementProps & { placeholder?: string; placeholderProps?: IReqoreSpanProps }
+) => (
+  <ReqoreP {...props.attributes} style={{ position: 'relative' }}>
+    {props.placeholder && (
+      <ReqoreSpan
+        inline
+        effect={{ opacity: 0.3 }}
+        {...props.placeholderProps}
+        contentEditable={false}
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          pointerEvents: 'none',
+          userSelect: 'none',
+          ...props.placeholderProps?.style,
+        }}
+      >
+        {props.placeholder}
+      </ReqoreSpan>
+    )}
+    {props.children}
+  </ReqoreP>
 );
 
 const insertTag = (
@@ -189,6 +213,8 @@ export const ReqoreRichTextEditor = forwardRef<
       panelProps,
       actions,
       customRenderLeaf,
+      placeholder,
+      placeholderProps,
       ...rest
     }: IReqoreRichTextEditorProps,
     ref
@@ -225,58 +251,67 @@ export const ReqoreRichTextEditor = forwardRef<
       }
     }, [JSON.stringify(value)]);
 
-    const renderElement = useCallback((props) => {
-      switch (props.element.type) {
-        case 'tag': {
-          const tagProps = getTagProps(props.element);
-          const finalProps = {
-            ...tagsProps,
-            ...tagProps,
-          };
+    const isEmpty = useMemo(() => {
+      return size(value) === 1 && size(value[0].children) === 1 && value[0].children[0].text === '';
+    }, [value]);
 
-          return (
-            <TemplateElement
-              {...props}
-              tagProps={{
-                ...finalProps,
-                size: rest.size ? getOneLessSize(rest.size) : finalProps.size || 'small',
-                onClick:
-                  !rest.readOnly && !rest.disabled
-                    ? (event) => {
-                        onTagClick?.(props.element);
-                        finalProps.onClick?.(event);
-                      }
-                    : undefined,
-                onRemoveClick:
-                  !rest.readOnly && !rest.disabled
-                    ? () => {
-                        try {
-                          const path = ReactEditor.findPath(editor, props.element);
-                          Transforms.removeNodes(editor, { at: path });
-                        } catch (error) {
-                          // Element may no longer be in the editor
-                          console.warn('Failed to remove tag:', error);
+    const renderElement = useCallback(
+      (props) => {
+        switch (props.element.type) {
+          case 'tag': {
+            const tagProps = getTagProps(props.element);
+            const finalProps = {
+              ...tagsProps,
+              ...tagProps,
+            };
+
+            return (
+              <TemplateElement
+                {...props}
+                tagProps={{
+                  ...finalProps,
+                  size: rest.size ? getOneLessSize(rest.size) : finalProps.size || 'small',
+                  onClick:
+                    !rest.readOnly && !rest.disabled
+                      ? (event) => {
+                          onTagClick?.(props.element);
+                          finalProps.onClick?.(event);
                         }
-                      }
-                    : undefined,
-              }}
-            />
-          );
+                      : undefined,
+                  onRemoveClick:
+                    !rest.readOnly && !rest.disabled
+                      ? () => {
+                          try {
+                            const path = ReactEditor.findPath(editor, props.element);
+                            Transforms.removeNodes(editor, { at: path });
+                          } catch (error) {
+                            // Element may no longer be in the editor
+                            console.warn('Failed to remove tag:', error);
+                          }
+                        }
+                      : undefined,
+                }}
+              />
+            );
+          }
+          default:
+            return (
+              <DefaultElement
+                {...props}
+                placeholder={isEmpty ? placeholder : undefined}
+                placeholderProps={isEmpty ? placeholderProps : undefined}
+              />
+            );
         }
-        default:
-          return <DefaultElement {...props} />;
-      }
-    }, []);
+      },
+      [isEmpty, placeholder, placeholderProps]
+    );
 
     const renderLeaf = useCallback(
       (props: RenderLeafProps) =>
         customRenderLeaf ? customRenderLeaf(props) : <Leaf {...props} />,
       [customRenderLeaf]
     );
-
-    const isEmpty = useMemo(() => {
-      return size(value) === 1 && size(value[0].children) === 1 && value[0].children[0].text === '';
-    }, [value]);
 
     const isMarkActive = useCallback((editor: Editor, format: string) => {
       const marks = Editor.marks(editor);

--- a/src/stories/Dropdown/DropdownTests.stories.tsx
+++ b/src/stories/Dropdown/DropdownTests.stories.tsx
@@ -332,7 +332,6 @@ export const EmptySearch: Story = {
 export const KeyboardNavigationWithArrowKeys: Story = {
   args: {
     component: ReqoreTextarea,
-    label: 'Keyboard Navigation Test',
     items: [
       {
         label: 'Item 1',
@@ -360,7 +359,7 @@ export const KeyboardNavigationWithArrowKeys: Story = {
     await sleep(200);
 
     // Click to open
-    await fireEvent.click(canvas.getAllByText('Keyboard Navigation Test')[0]);
+    await fireEvent.click(document.querySelector('.reqore-textarea'));
     await sleep(200);
 
     // Get the input for keyboard events

--- a/src/stories/Dropdown/DropdownTests.stories.tsx
+++ b/src/stories/Dropdown/DropdownTests.stories.tsx
@@ -6,7 +6,7 @@ import { _testsWaitForText } from '../../../__tests__/utils';
 import ReqoreButton, { IReqoreButtonProps } from '../../components/Button';
 import { IReqoreDropdownProps } from '../../components/Dropdown';
 import { sleep } from '../../helpers/utils';
-import { ReqoreDropdown } from '../../index';
+import { ReqoreDropdown, ReqoreTextarea } from '../../index';
 import { StoryMeta } from '../utils';
 import { argManager } from '../utils/args';
 import { WithChildItems } from './Dropdown.stories';
@@ -331,6 +331,7 @@ export const EmptySearch: Story = {
 };
 export const KeyboardNavigationWithArrowKeys: Story = {
   args: {
+    component: ReqoreTextarea,
     label: 'Keyboard Navigation Test',
     items: [
       {

--- a/src/stories/RichTextEditor/RichTextEditor.stories.tsx
+++ b/src/stories/RichTextEditor/RichTextEditor.stories.tsx
@@ -40,6 +40,11 @@ type Story = StoryObj<typeof meta>;
 
 export default meta;
 export const Empty: Story = {};
+export const WithPlaceholder: Story = {
+  args: {
+    placeholder: 'Type something here...',
+  },
+};
 export const WithDefaultValue: Story = {
   args: {
     value: [


### PR DESCRIPTION
## Summary
- Arrow keys now navigate dropdown items regardless of which element has DOM focus
- Enables the `aria-activedescendant` pattern: an external input (e.g., rich text editor) keeps focus while arrow keys traverse the dropdown list
- Adds `passKeyHandler` and `listId` props for explicit external keyboard control and accessibility

## How it works
- When the dropdown list mounts (i.e., the dropdown is open), a `document.addEventListener('keydown')` listener is registered
- Events targeting elements **inside** the dropdown (filter input, menu) are skipped — they're already handled by the existing `onKeyDown` props
- Events from **outside** (an external input, a button, etc.) are forwarded to the dropdown's keyboard handler

## Test plan
- [x] `yarn precheck` passes (lint, 369 tests, build)
- [ ] Open Storybook → Dropdown Tests → KeyboardNavigationWithArrowKeys
- [ ] Verify arrow keys highlight items even when the dropdown button (not filter input) has focus
- [ ] Verify Enter selects the highlighted item
- [ ] Verify no interference with other keyboard shortcuts when dropdown is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)