### PR TITLE
Add inheritCustomTheme prop for theme inheritance

### DIFF
--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -374,6 +374,7 @@ export const ReqoreAccordion = memo(
         allowMultiple = true,
         size = 'normal',
         customTheme,
+        inheritCustomTheme,
         intent,
         fluid,
         flat,
@@ -390,7 +391,7 @@ export const ReqoreAccordion = memo(
       },
       ref
     ) => {
-      const theme = useReqoreTheme('main', customTheme, intent);
+      const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
 
       const [openItems, setOpenItems] = useState<Record<number, boolean>>(() =>
         items.reduce((acc, item, index) => {

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -170,7 +170,7 @@ const ReqoreBreadcrumbs: React.FC<IReqoreBreadcrumbsProps> = ({
   ...rest
 }: IReqoreBreadcrumbsProps) => {
   const [ref, { width }] = useMeasure();
-  const theme = useReqoreTheme('breadcrumbs', customTheme);
+  const theme = useReqoreTheme('breadcrumbs', customTheme, undefined);
   const transformedItems = useMemo(
     () => (responsive ? getTransformedItems(items, _testWidth || width, size) : items),
     [items, width, _testWidth, size]

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -259,6 +259,7 @@ const Checkbox = forwardRef<HTMLDivElement, IReqoreCheckboxProps>(
       intent,
       effect,
       customTheme,
+        inheritCustomTheme,
       wrapLabel,
       onCheckClick,
       onUncheckClick,
@@ -273,7 +274,7 @@ const Checkbox = forwardRef<HTMLDivElement, IReqoreCheckboxProps>(
       : checked === undefined
       ? unsetIntent || intent
       : uncheckedIntent || intent;
-    const theme = useReqoreTheme('main', customTheme, _intent);
+    const theme = useReqoreTheme('main', customTheme, _intent, undefined, inheritCustomTheme);
 
     const width = useMemo(() => {
       const selectedWidth = checked ? onWidth : offWidth;

--- a/src/components/Collection/item.tsx
+++ b/src/components/Collection/item.tsx
@@ -93,7 +93,7 @@ export const ReqoreCollectionItem = ({
   const [contentRef, sizes] = useMeasure();
   const originalDimensions = useRef(null);
   const [position, setPosition] = useState(undefined);
-  const theme = useReqoreTheme('main', rest.customTheme);
+  const theme = useReqoreTheme('main', rest.customTheme, undefined, undefined, rest.inheritCustomTheme);
   const [dimensions, setDimensions] = useState<any>({
     minWidth: undefined,
     minHeight: undefined,

--- a/src/components/DatePicker/index.tsx
+++ b/src/components/DatePicker/index.tsx
@@ -129,6 +129,7 @@ export const DatePicker = <T extends TDateValue>({
   pill,
   intent,
   customTheme,
+        inheritCustomTheme,
   granularity = 'minute',
   hourCycle = 24,
   hideTimeZone = true,
@@ -167,7 +168,7 @@ export const DatePicker = <T extends TDateValue>({
 
   const ref = useRef(null);
 
-  const theme = useReqoreTheme('main', customTheme, intent);
+  const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
   const popoverData = useRef({} as IPopoverControls);
   // use ref to save value type since datepicker can have null values
   const isStringRef = useRef(typeof _value === 'string');

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -157,6 +157,7 @@ export const ReqoreDrawer: React.FC<IReqoreDrawerProps> = memo(
     isOpen,
     isHidden,
     customTheme,
+        inheritCustomTheme,
     position = 'right',
     maxSize,
     minSize = '150px',
@@ -188,7 +189,7 @@ export const ReqoreDrawer: React.FC<IReqoreDrawerProps> = memo(
     const confirmAction = useReqoreProperty('confirmAction');
     const customPortalId = useReqoreProperty('customPortalId');
     const getAndIncreaseZIndex = useReqoreProperty('getAndIncreaseZIndex');
-    const theme = useReqoreTheme('main', customTheme, intent);
+    const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
     const layout = useMemo(
       () =>
         _isModal
@@ -379,7 +380,7 @@ export const ReqoreDrawer: React.FC<IReqoreDrawerProps> = memo(
     return createPortal(
       transitions((styles: any, item) =>
         item ? (
-          <ReqoreThemeProvider theme={theme}>
+          <ReqoreThemeProvider theme={theme} customTheme={customTheme}>
             {hasBackdrop && !_isHidden ? (
               <ReqoreBackdrop
                 onClose={handleClose}

--- a/src/components/Dropdown/list.tsx
+++ b/src/components/Dropdown/list.tsx
@@ -110,6 +110,7 @@ const ReqoreDropdownList = memo(
     filter,
     customElements,
     customTheme,
+        inheritCustomTheme,
     intent,
     keyboardNavigation = true,
     passKeyHandler,
@@ -153,7 +154,7 @@ const ReqoreDropdownList = memo(
       }
     }, [currentSelectedItem, selectedItems, _level, onSelectedItemsChange]);
 
-    const theme = useReqoreTheme('main', customTheme, intent);
+    const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
 
     useEffect(() => {
       setItems(items);

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -63,6 +63,7 @@ export const ReqoreEmptyState = memo(
         actions,
         size = 'normal',
         customTheme,
+        inheritCustomTheme,
         intent,
         fluid,
         flat = true,
@@ -78,7 +79,7 @@ export const ReqoreEmptyState = memo(
       },
       ref
     ) => {
-      const theme = useReqoreTheme('main', customTheme, intent);
+      const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
 
       const iconSize = useMemo(() => getOneHigherSize(size), [size]);
       const descriptionSize = useMemo(() => getOneLessSize(size), [size]);

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -210,6 +210,7 @@ const ReqoreInput = forwardRef<HTMLDivElement, IReqoreInputProps>(
       minimal,
       readOnly,
       customTheme,
+        inheritCustomTheme,
       intent,
       wrapperStyle,
       focusRules,
@@ -224,7 +225,7 @@ const ReqoreInput = forwardRef<HTMLDivElement, IReqoreInputProps>(
   ) => {
     const { targetRef } = useCombinedRefs(ref);
     const [inputRef, setInputRef] = useState<HTMLInputElement>(null);
-    const theme = useReqoreTheme('main', customTheme, intent);
+    const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
 
     useAutoFocus(inputRef, readOnly || rest.disabled ? undefined : focusRules, rest.onChange);
 

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -120,7 +120,7 @@ const ReqoreMenu = memo(
 
       return (
         <ReqoreErrorBoundary {...errorBoundaryOptions}>
-          <ReqoreThemeProvider theme={theme}>
+          <ReqoreThemeProvider theme={theme} customTheme={customTheme}>
             <StyledReqoreMenu
               {...rest}
               {...resizable}

--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -79,6 +79,7 @@ const ReqoreMessage = memo(
         minimal,
         size = 'normal',
         customTheme,
+        inheritCustomTheme,
         iconColor,
         fixed,
         fluid,
@@ -88,7 +89,7 @@ const ReqoreMessage = memo(
       ref
     ) => {
       const [internalTimeout, setInternalTimeout] = useState<NodeJS.Timeout | null>(null);
-      const theme = useReqoreTheme('main', customTheme, intent);
+      const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
 
       useMount(() => {
         if (duration) {

--- a/src/components/Notifications/notification.tsx
+++ b/src/components/Notifications/notification.tsx
@@ -269,11 +269,12 @@ const ReqoreNotification = forwardRef<HTMLDivElement, IReqoreNotificationProps>(
       blur,
       size = 'normal',
       customTheme,
+        inheritCustomTheme,
     },
     ref: any
   ) => {
     const [internalTimeout, setInternalTimeout] = useState(null);
-    const theme = useReqoreTheme('main', customTheme, type || intent, 'notifications');
+    const theme = useReqoreTheme('main', customTheme, type || intent, 'notifications', inheritCustomTheme);
 
     const transitions = useTransition(true, {
       from: { opacity: 0, transform: 'scale(0.9)' },

--- a/src/components/Panel/index.tsx
+++ b/src/components/Panel/index.tsx
@@ -491,6 +491,7 @@ export const ReqorePanel = forwardRef<HTMLDivElement, IReqorePanelProps>(
       bottomActions = [],
       isCollapsed,
       customTheme,
+      inheritCustomTheme,
       icon,
       iconImage,
       intent,
@@ -540,7 +541,10 @@ export const ReqorePanel = forwardRef<HTMLDivElement, IReqorePanelProps>(
       customTheme ||
         (contentEffect?.gradient && minimal
           ? { main: Object.values(contentEffect.gradient.colors)[0] as TReqoreEffectColor }
-          : undefined)
+          : undefined),
+      undefined,
+      undefined,
+      inheritCustomTheme
     );
 
     useEffect(() => {

--- a/src/components/Paragraph/index.tsx
+++ b/src/components/Paragraph/index.tsx
@@ -38,6 +38,7 @@ export const ReqoreP = memo(
         size,
         children,
         customTheme,
+        inheritCustomTheme,
         intent,
         className,
         block = true,
@@ -46,7 +47,7 @@ export const ReqoreP = memo(
       }: IReqoreParagraphProps,
       ref
     ) => {
-      const theme = useReqoreTheme('main', customTheme, intent);
+      const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
 
       return (
         <ReqoreTooltipComponent

--- a/src/components/Progress/index.tsx
+++ b/src/components/Progress/index.tsx
@@ -203,6 +203,7 @@ const ReqoreProgress = memo(
         label,
         animated = false,
         customTheme,
+        inheritCustomTheme,
         intent,
         fluid = false,
         rounded = true,
@@ -222,9 +223,9 @@ const ReqoreProgress = memo(
       ref
     ) => {
       // Theme with intent for the progress bar
-      const theme = useReqoreTheme('main', customTheme, intent);
+      const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
       // Base theme without intent for labels
-      const baseTheme = useReqoreTheme('main', customTheme);
+      const baseTheme = useReqoreTheme('main', customTheme, undefined, undefined, inheritCustomTheme);
 
       const percentage = useMemo(() => {
         if (indeterminate || max === 0) return 0;

--- a/src/components/Rating/index.tsx
+++ b/src/components/Rating/index.tsx
@@ -136,6 +136,7 @@ const ReqoreRating = memo(
         readOnly,
         intent,
         customTheme,
+        inheritCustomTheme,
         tooltip,
         className,
         labelProps,
@@ -145,7 +146,7 @@ const ReqoreRating = memo(
       },
       ref
     ) => {
-      const theme = useReqoreTheme('main', customTheme, intent);
+      const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
       const [hoverValue, setHoverValue] = useState<number | null>(null);
 
       const isInteractive = !disabled && !readOnly && !!onChange;

--- a/src/components/SegmentedControl/index.tsx
+++ b/src/components/SegmentedControl/index.tsx
@@ -290,6 +290,7 @@ const ReqoreSegmentedControl = memo(
         readOnly,
         intent,
         customTheme,
+        inheritCustomTheme,
         fluid,
         className,
         _testWidth,
@@ -298,7 +299,7 @@ const ReqoreSegmentedControl = memo(
       ref
     ) => {
       const animations = useReqoreProperty('animations');
-      const theme = useReqoreTheme('main', customTheme, intent);
+      const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
 
       const [_value, _setValue] = useState<string | undefined>(
         value ?? defaultValue ?? items[0]?.value

--- a/src/components/Spacer/index.tsx
+++ b/src/components/Spacer/index.tsx
@@ -90,12 +90,13 @@ export interface IReqoreSpacerProps
 export const ReqoreSpacer = memo(
   ({
     customTheme,
+        inheritCustomTheme,
     intent,
     lineSize = 'none',
     align,
     ...rest
   }: IReqoreSpacerProps & { horizontal?: boolean; vertical?: boolean }) => {
-    const theme = useReqoreTheme('main', customTheme, intent);
+    const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
     let { horizontal, vertical } = rest;
 
     // The user is using old version of the component

--- a/src/components/Span/index.tsx
+++ b/src/components/Span/index.tsx
@@ -36,6 +36,7 @@ export const ReqoreSpan = memo(
         size,
         children,
         customTheme,
+        inheritCustomTheme,
         intent,
         className,
         inline = false,
@@ -44,7 +45,7 @@ export const ReqoreSpan = memo(
       }: IReqoreSpanProps,
       ref
     ) => {
-      const theme = useReqoreTheme('main', customTheme, intent);
+      const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
 
       return (
         <ReqoreTooltipComponent

--- a/src/components/Statistic/index.tsx
+++ b/src/components/Statistic/index.tsx
@@ -175,6 +175,7 @@ const ReqoreStatistic = memo(
         align = 'center',
         size = 'normal',
         customTheme,
+        inheritCustomTheme,
         intent,
         fluid,
         flat,
@@ -188,7 +189,7 @@ const ReqoreStatistic = memo(
       },
       ref
     ) => {
-      const theme = useReqoreTheme('main', customTheme, intent);
+      const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
 
       const secondarySize = useMemo(() => getOneLessSize(size), [size]);
       const flexAlign = useMemo(() => alignToFlexAlign(align), [align]);

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -865,7 +865,7 @@ const ReqoreTable = ({
         getContentRef={wrapperRef}
         badge={badge}
       >
-        <ReqoreThemeProvider theme={theme}>
+        <ReqoreThemeProvider theme={theme} customTheme={rest.customTheme}>
           <ReqorePaginationContainer<IReqoreTableRowData>
             items={transformedData}
             type={

--- a/src/components/Tabs/item.tsx
+++ b/src/components/Tabs/item.tsx
@@ -139,7 +139,7 @@ const ReqoreTabsListItem = memo(
       const [isStillPending, setStillPending] = useState(false);
       const [loadingTimer, setLoadingTimer] = useState(null);
       const { targetRef } = useCombinedRefs(ref);
-      const theme = useReqoreTheme('main', customTheme);
+      const theme = useReqoreTheme('main', customTheme, undefined);
 
       useUpdateEffect(() => {
         if (isPending) {

--- a/src/components/Tabs/list.tsx
+++ b/src/components/Tabs/list.tsx
@@ -255,7 +255,7 @@ const ReqoreTabsList = ({
   );
 
   return (
-    <ReqoreThemeProvider theme={theme}>
+    <ReqoreThemeProvider theme={theme} customTheme={customTheme}>
       <StyledReqoreTabsList
         {...rest}
         size={size}

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -335,6 +335,7 @@ const ReqoreTag = forwardRef<HTMLSpanElement, IReqoreTagProps>(
       color,
       minimal,
       customTheme,
+        inheritCustomTheme,
       wrap = false,
       width,
       leftIconColor,
@@ -353,7 +354,7 @@ const ReqoreTag = forwardRef<HTMLSpanElement, IReqoreTagProps>(
     }: IReqoreTagProps,
     ref
   ) => {
-    const theme: IReqoreTheme = useReqoreTheme('main', customTheme);
+    const theme: IReqoreTheme = useReqoreTheme('main', customTheme, undefined, undefined, inheritCustomTheme);
 
     // If color or intent was specified, set the color
     const getCustomColor = useCallback(

--- a/src/components/Textarea/index.tsx
+++ b/src/components/Textarea/index.tsx
@@ -165,6 +165,7 @@ function Textarea<T>(
     fluid,
     tooltip,
     customTheme,
+        inheritCustomTheme,
     intent,
     rounded = true,
     wrapperStyle,
@@ -179,7 +180,7 @@ function Textarea<T>(
 ) {
   const { targetRef }: any = useCombinedRefs(ref);
   const [inputRef, setInputRef] = useState<HTMLTextAreaElement>(null);
-  const theme = useReqoreTheme('main', customTheme, intent);
+  const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
   const [_value, setValue] = useState(value || '');
   const [popoverData, setPopoverData] = useState<IPopoverControls>(null);
   const uuid = useRef(nanoid());

--- a/src/components/Timeline/index.tsx
+++ b/src/components/Timeline/index.tsx
@@ -436,6 +436,7 @@ const ReqoreTimeline = memo(
         items,
         size = 'normal',
         customTheme,
+        inheritCustomTheme,
         intent,
         fluid = false,
         className,
@@ -445,8 +446,8 @@ const ReqoreTimeline = memo(
       },
       ref
     ) => {
-      const theme = useReqoreTheme('main', customTheme, intent);
-      const baseTheme = useReqoreTheme('main', customTheme);
+      const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
+      const baseTheme = useReqoreTheme('main', customTheme, undefined, undefined, inheritCustomTheme);
 
       // Internal state used only in uncontrolled mode
       const [internalCollapsedStates, setInternalCollapsedStates] = useState<

--- a/src/containers/ThemeProvider.tsx
+++ b/src/containers/ThemeProvider.tsx
@@ -1,12 +1,26 @@
 import { ThemeProvider } from 'styled-components';
 import { useContext } from 'use-context-selector';
 import { IReqoreTheme } from '../constants/theme';
+import CustomThemeContext from '../context/CustomThemeContext';
 import ThemeContext from '../context/ThemeContext';
+import { IReqoreCustomTheme } from '../hooks/useTheme';
 
-const ReqoreThemeProvider = ({ children, theme }: { children: any; theme?: IReqoreTheme }) => {
+const ReqoreThemeProvider = ({
+  children,
+  theme,
+  customTheme,
+}: {
+  children: any;
+  theme?: IReqoreTheme;
+  customTheme?: IReqoreCustomTheme;
+}) => {
   const _theme: IReqoreTheme = useContext(ThemeContext);
 
-  return <ThemeProvider theme={theme || _theme}>{children}</ThemeProvider>;
+  return (
+    <CustomThemeContext.Provider value={customTheme}>
+      <ThemeProvider theme={theme || _theme}>{children}</ThemeProvider>
+    </CustomThemeContext.Provider>
+  );
 };
 
 export default ReqoreThemeProvider;

--- a/src/context/CustomThemeContext.tsx
+++ b/src/context/CustomThemeContext.tsx
@@ -1,0 +1,6 @@
+import { createContext } from 'use-context-selector';
+import { IReqoreCustomTheme } from '../hooks/useTheme';
+
+const CustomThemeContext = createContext<IReqoreCustomTheme | undefined>(undefined);
+
+export default CustomThemeContext;

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,7 +1,9 @@
 import { cloneDeep } from 'lodash';
 import { useMemo } from 'react';
+import { useContext } from 'use-context-selector';
 import { TReqoreEffectColor } from '../components/Effect';
 import { IReqoreTheme, TReqoreIntent } from '../constants/theme';
+import CustomThemeContext from '../context/CustomThemeContext';
 import { getColorFromMaybeString, mergeThemes } from '../helpers/colors';
 import { useReqoreProperty } from './useReqoreContext';
 
@@ -16,25 +18,39 @@ export interface IReqoreCustomTheme extends Partial<Omit<IReqoreTheme, 'main' | 
 
 export const useReqoreTheme = (
   element?: string,
-  customTheme: IReqoreCustomTheme = {},
+  customTheme?: IReqoreCustomTheme,
   intent?: TReqoreIntent,
-  intentsKey: 'intents' | 'notifications' = 'intents'
+  intentsKey: 'intents' | 'notifications' = 'intents',
+  inheritCustomTheme: boolean = true
 ): IReqoreTheme => {
   const theme: IReqoreTheme = useReqoreProperty('theme');
+  const parentCustomTheme = useContext(CustomThemeContext);
+
+  const resolvedCustomTheme = useMemo(() => {
+    // Explicit customTheme always wins
+    if (customTheme) {
+      return customTheme;
+    }
+    // Inherit from parent context if allowed
+    if (inheritCustomTheme && parentCustomTheme) {
+      return parentCustomTheme;
+    }
+    return {};
+  }, [customTheme, inheritCustomTheme, parentCustomTheme]);
 
   const finalTheme = useMemo(() => {
     if (!element) {
       return theme;
     }
 
-    const _customTheme: IReqoreCustomTheme = cloneDeep(customTheme);
+    const _customTheme: IReqoreCustomTheme = cloneDeep(resolvedCustomTheme);
 
     if (_customTheme.main) {
-      _customTheme.main = getColorFromMaybeString(theme, customTheme.main);
+      _customTheme.main = getColorFromMaybeString(theme, resolvedCustomTheme.main);
     }
 
     if (_customTheme.text?.color) {
-      _customTheme.text.color = getColorFromMaybeString(theme, customTheme.text.color);
+      _customTheme.text.color = getColorFromMaybeString(theme, resolvedCustomTheme.text.color);
     }
 
     if (element === 'main' && intent) {
@@ -42,7 +58,7 @@ export const useReqoreTheme = (
     }
 
     return mergeThemes(element, theme, _customTheme) as IReqoreTheme;
-  }, [JSON.stringify(theme), element, JSON.stringify(customTheme), intent, intentsKey]);
+  }, [JSON.stringify(theme), element, JSON.stringify(resolvedCustomTheme), intent, intentsKey]);
 
   return finalTheme;
 };

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -66,6 +66,13 @@ export interface IWithReqoreCustomTheme {
    * <ReqoreInput customTheme={{ main: '#ff0000', text: { color: '#0000ff' } }} />
    */
   customTheme?: IReqoreCustomTheme;
+  /**
+   * Whether to inherit a custom theme from a parent component's context.
+   * Set to false to opt out of an ancestor's custom theme.
+   * @default true
+   * @type boolean
+   */
+  inheritCustomTheme?: boolean;
 }
 
 export interface IWithReqoreTooltip {


### PR DESCRIPTION
Introduce the `inheritCustomTheme` prop to allow components to inherit custom themes from their parent context. This change enhances theme management across components by providing an option to opt-out of inherited themes.