### PR TITLE
Add column visibility control to IReqoreTableProps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.63.20",
+  "version": "0.63.21",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -151,6 +151,7 @@ export interface IReqoreTableProps extends IReqorePanelProps {
   striped?: boolean;
   emptyMessage?: string;
   showHelp?: boolean;
+  showColumnsOptions?: boolean;
 
   onRowClick?: IReqoreTableRowClick;
   headerCellComponent?: IReqoreCustomHeaderCellComponent;
@@ -260,6 +261,7 @@ const ReqoreTable = ({
   exportable,
   exportMapper,
   showHelp,
+  showColumnsOptions,
   ...rest
 }: IReqoreTableProps) => {
   const leftTableRef = useRef<HTMLDivElement>(null);
@@ -459,9 +461,7 @@ const ReqoreTable = ({
 
     // Filter by global query
     let filteredData = hasQuery
-      ? _data.filter((datum) =>
-          JSON.stringify(datum).toLowerCase().includes(normalizedQuery)
-        )
+      ? _data.filter((datum) => JSON.stringify(datum).toLowerCase().includes(normalizedQuery))
       : _data;
 
     // Filter by column filters
@@ -603,7 +603,7 @@ const ReqoreTable = ({
       return finalActions;
     }
 
-    if (count(columnsList)) {
+    if (count(columnsList) && showColumnsOptions) {
       let columnsCount = getColumnsCount(getOnlyShownColumns(finalColumns, sizes.width));
 
       if (selectable) {

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -614,7 +614,7 @@ const ReqoreTable = ({
         icon: 'LayoutColumnLine',
         className: 'reqore-table-columns-options',
         badge: columnsCount,
-        intent: hasHiddenColumns(finalColumns) ? 'info' : undefined,
+        active: hasHiddenColumns(finalColumns) ? true : undefined,
         multiSelect: true,
         actions: columnsList,
       });

--- a/src/stories/Table/Table.stories.tsx
+++ b/src/stories/Table/Table.stories.tsx
@@ -533,6 +533,7 @@ export const AllFiltersActive: Story = {
 
 export const HiddenColumns: Story = {
   args: {
+    showColumnsOptions: true,
     columns: defaultColumnsWithHiddenColumns,
   },
 };


### PR DESCRIPTION
Introduce a `showColumnsOptions` prop for controlling column visibility and update the column options to use 'active' for visibility management.