### PR TITLE
feat(RichTextEditor): expose Slate `decorate` prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.68.2",
+  "version": "0.68.3",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/RichTextEditor/index.tsx
+++ b/src/components/RichTextEditor/index.tsx
@@ -53,6 +53,15 @@ export interface IReqoreRichTextEditorProps
     };
   };
   customRenderLeaf?: (props: RenderLeafProps) => JSX.Element;
+  /**
+   * Slate `decorate` function. Receives a `[Node, Path]` entry and returns
+   * `Range[]` with custom properties applied to each range. Each range's
+   * properties are then passed to `renderLeaf` / `customRenderLeaf` as leaf
+   * marks, which is the standard Slate way to overlay syntax highlighting,
+   * search highlights, error underlines, etc. on top of the document without
+   * mutating it.
+   */
+  decorate?: EditableProps['decorate'];
   getTagProps?: (tag: CustomElement) => IReqoreTagProps;
   onTagClick?: (tag: CustomElement) => void;
   tagsProps?: IReqoreTagProps;
@@ -213,6 +222,7 @@ export const ReqoreRichTextEditor = forwardRef<
       panelProps,
       actions,
       customRenderLeaf,
+      decorate,
       placeholder,
       placeholderProps,
       ...rest
@@ -429,10 +439,11 @@ export const ReqoreRichTextEditor = forwardRef<
             onChange?.(data as CustomElement[]);
           }}
         >
-          <ReqoreTextarea<Pick<EditableProps, 'renderElement' | 'renderLeaf'>>
+          <ReqoreTextarea<Pick<EditableProps, 'renderElement' | 'renderLeaf' | 'decorate'>>
             {...rest}
             renderElement={renderElement}
             renderLeaf={renderLeaf}
+            decorate={decorate}
             as={Editable}
             style={{
               lineHeight: 1.5,

--- a/src/stories/RichTextEditor/RichTextEditor.stories.tsx
+++ b/src/stories/RichTextEditor/RichTextEditor.stories.tsx
@@ -1,7 +1,8 @@
 import { expect, jest } from '@storybook/jest';
 import { StoryObj } from '@storybook/react';
 import { userEvent } from '@storybook/testing-library';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
+import { NodeEntry, Range, Text } from 'slate';
 import { RenderLeafProps } from 'slate-react/dist/components/editable';
 import { ReqoreSpan } from '../../components/Span';
 import { useMount } from 'react-use';
@@ -350,6 +351,94 @@ export const UpdatesFromInside: Story = {
         children: [{ text: 'This is the default UPDATED text' }],
       },
     ]);
+  },
+};
+
+/**
+ * Demonstrates the `decorate` prop, used to overlay syntax-highlighting-style
+ * marks on top of the document without mutating it. The decorate function
+ * receives a `[Node, Path]` entry and returns `Range[]` with custom mark
+ * properties; those marks are then read by `customRenderLeaf` to apply
+ * styling. This is the standard Slate pattern for syntax highlighting,
+ * search highlights, error underlines, etc.
+ */
+export const WithDecorate: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+
+    // Highlight occurrences of "TODO" and "ERROR" — the classic
+    // syntax-highlighting-via-decorate pattern.
+    const decorate = useCallback(([node, path]: NodeEntry): Range[] => {
+      const ranges: Range[] = [];
+      if (!Text.isText(node)) {
+        return ranges;
+      }
+      const text = node.text;
+      const pattern = /\b(TODO|ERROR)\b/g;
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(text)) !== null) {
+        ranges.push({
+          anchor: { path, offset: match.index },
+          focus: { path, offset: match.index + match[0].length },
+          highlight: match[1] === 'TODO' ? 'todo' : 'error',
+        } as Range & { highlight: string });
+      }
+      return ranges;
+    }, []);
+
+    const customRenderLeaf = useCallback(
+      ({ attributes, children, leaf }: RenderLeafProps & { leaf: { highlight?: string } }) => (
+        <ReqoreSpan
+          inline
+          {...attributes}
+          style={{
+            backgroundColor:
+              leaf.highlight === 'todo'
+                ? 'rgba(255, 217, 0, 0.25)'
+                : leaf.highlight === 'error'
+                ? 'rgba(255, 60, 60, 0.25)'
+                : undefined,
+            fontWeight: leaf.highlight ? 600 : undefined,
+          }}
+        >
+          {children}
+        </ReqoreSpan>
+      ),
+      []
+    );
+
+    return (
+      <ReqoreRichTextEditor
+        {...args}
+        value={value}
+        onChange={(val) => {
+          setValue(val);
+          args.onChange?.(val);
+        }}
+        decorate={decorate}
+        customRenderLeaf={customRenderLeaf}
+      />
+    );
+  },
+  args: {
+    value: [
+      {
+        type: 'paragraph',
+        children: [{ text: 'TODO: ship this feature. ERROR if not done by Friday.' }],
+      },
+      {
+        type: 'paragraph',
+        children: [{ text: 'Plain second paragraph with no highlights.' }],
+      },
+    ],
+  },
+  play: async () => {
+    // Confirm the editor mounted and the document contains the source text;
+    // the decorate ranges are applied by Slate as React reconciles, so the
+    // text content survives intact.
+    await expect(document.querySelector('div[contenteditable]')).toBeInTheDocument();
+    await expect(document.querySelector('div[contenteditable]')).toHaveTextContent('TODO');
+    await expect(document.querySelector('div[contenteditable]')).toHaveTextContent('ERROR');
   },
 };
 


### PR DESCRIPTION
## Summary

Add `decorate?: EditableProps['decorate']` to `IReqoreRichTextEditorProps` and pass it through to the underlying Slate `<Editable>`. This is the standard Slate hook for overlaying syntax-highlighting / search-match / error-underline ranges on a document without mutating it — each range's custom properties flow into `renderLeaf` / `customRenderLeaf` as leaf marks.

## Why

`ReqoreRichTextEditor` is a curated wrapper around Slate that doesn't blindly re-export every `<Editable>` prop. Until now, consumers who needed `decorate` had two options:

1. Spread `{...({ decorate } as any)}` on the component to bypass TypeScript via the rest-prop runtime fallthrough. Works at runtime but defeats type safety and hides the contract from anyone reading the prop interface.
2. Contribute the prop upstream.

This PR is option 2. The same precedent was set for `customRenderLeaf` in v0.63.5 (commit 66ecedf) — same author, same scenario, same fix.

## Use case

The DPQL editor that's being extracted from qorus-ide PR [#203](https://github.com/qoretechnologies/qorus-ide/pull/203) ([qorus-ide#196](https://github.com/qoretechnologies/qorus-ide/issues/196)) into Reqraft uses Slate's `decorate` to drive DPQL syntax highlighting (keywords, strings, numbers, operators, comments, functions). With this prop properly typed, Reqraft can pass `decorate={decorate}` end-to-end with no casts. Any future consumer wanting search-match highlights, error underlines, diff highlights, etc. gets the same path.

## Changes

- **`src/components/RichTextEditor/index.tsx`**
  - Added `decorate?: EditableProps['decorate']` to `IReqoreRichTextEditorProps` with a doc comment explaining the standard Slate-syntax-highlighting pattern.
  - Destructured `decorate` from props.
  - Passed it explicitly to the inner `<ReqoreTextarea>` (which renders `as={Editable}`).
  - Expanded the `<ReqoreTextarea<Pick<EditableProps, …>>>` generic to include `'decorate'` so the type system reflects the new pass-through.
- **`src/stories/RichTextEditor/RichTextEditor.stories.tsx`** — new `WithDecorate` story mirroring the `WithCustomRenderLeaf` precedent. Demonstrates regex-driven highlights for `TODO` / `ERROR` tokens (the canonical syntax-highlighting-via-decorate pattern). Includes a play test asserting the document mounted with both keywords visible.
- **`package.json`** — version bump `0.68.2` → `0.68.3` (patch — matches the convention from commit 66ecedf when `customRenderLeaf` was added).

## Backward compatibility

Fully backward compatible. The prop is optional. Existing consumers that don't pass it see no behavior change. Consumers who currently pass it via the `{...({ decorate } as any)}` runtime fallthrough will continue to work, and can clean up the cast at their leisure.

## Test plan

- [x] `yarn build:test:prod` clean
- [x] `yarn lint` clean
- [x] `yarn test` — 579 / 579 tests pass
- [x] `WithDecorate` story renders with TODO/ERROR highlighted
- [ ] Storybook visual regression (Chromatic — fires on merge)

## Context

Part of the cross-repo DPQL editor extraction tracked at qoretechnologies/toolkit-react#61. This is the first step:

1. **Reqore** — this PR (expose `decorate`).
2. **Reqraft** ([toolkit-react](https://github.com/qoretechnologies/toolkit-react)) — lift the DPQL editor from qorus-ide as a properly-released Reqraft component. Already implemented locally; depends on this PR landing first.
3. **qorus-ide** — import the new Reqraft component, deprecating the in-tree editor on PR [qorus-ide#203](https://github.com/qoretechnologies/qorus-ide/pull/203).