### PR TITLE
Fix Dropdown to forward offsetX/offsetY to Popover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.68.3",
+  "version": "0.68.4",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -140,6 +140,8 @@ function ReqoreDropdown<T = IReqoreButtonProps>({
   onBeforeClose,
   onBeforeOpen,
   popoverId,
+  offsetX,
+  offsetY,
   ...rest
 }: IReqoreDropdownProps & T) {
   // Track the selected item at each navigation level
@@ -246,6 +248,8 @@ function ReqoreDropdown<T = IReqoreButtonProps>({
       onBeforeClose={onBeforeClose}
       onBeforeOpen={onBeforeOpen}
       id={popoverId}
+      offsetX={offsetX}
+      offsetY={offsetY}
     >
       {children || label}
     </ReqorePopover>


### PR DESCRIPTION
Enable the `ReqoreDropdown` component to forward `offsetX` and `offsetY` props to the inner `ReqorePopover`, allowing for better positioning control. Update the package version to 0.68.4.