### PR TITLE
fix(Textarea, RichTextEditor): null-safe blur + complete renderElement deps

### DIFF
--- a/src/components/RichTextEditor/index.tsx
+++ b/src/components/RichTextEditor/index.tsx
@@ -314,7 +314,28 @@ export const ReqoreRichTextEditor = forwardRef<
             );
         }
       },
-      [isEmpty, placeholder, placeholderProps]
+      // All values read inside the callback must be listed here.
+      // `editor` is stable (created once via `useState` initializer)
+      // but listed for completeness. The callback-shaped props
+      // (`getTagProps`, `onTagClick`) and the `rest`-derived flags
+      // (`size`, `readOnly`, `disabled`) need to be tracked so the
+      // memo invalidates when the parent passes new ones — otherwise
+      // tag chips render with stale click handlers / sizes.
+      // Consumers that pass non-stable callbacks via inline arrow
+      // functions will cause re-memoization on every render; pass
+      // stable refs (`useCallback`) for best performance.
+      [
+        isEmpty,
+        placeholder,
+        placeholderProps,
+        editor,
+        getTagProps,
+        tagsProps,
+        onTagClick,
+        rest.size,
+        rest.readOnly,
+        rest.disabled,
+      ]
     );
 
     const renderLeaf = useCallback(

--- a/src/components/Textarea/index.tsx
+++ b/src/components/Textarea/index.tsx
@@ -217,7 +217,15 @@ function Textarea<T>(
 
   const handleBlur = useCallback(
     (e) => {
-      if (e.relatedTarget.closest(`#id-${uuid.current}`) === null) {
+      // `relatedTarget` is `null` when focus leaves the element without
+      // moving to another focusable element — e.g. clicking the
+      // background, switching tabs, pressing Escape, or focus loss to
+      // browser chrome. Without this guard, `.closest()` throws a
+      // TypeError and the popover never closes.
+      if (
+        !e.relatedTarget ||
+        e.relatedTarget.closest(`#id-${uuid.current}`) === null
+      ) {
         popoverData?.close();
       }
     },


### PR DESCRIPTION
## Summary

Two correctness fixes in components adjacent to the rich-text editing stack, both surfaced while integrating Reqore into the toolkit-react `SmartEditor` primitive.

- **`Textarea.handleBlur`** — guards against null `relatedTarget`. The previous code threw `TypeError` when focus left the textarea without moving to another focusable element (clicking the background, switching tabs, Escape, etc.).
- **`RichTextEditor.renderElement`** — completes the `useCallback` deps array. The previous `[isEmpty, placeholder, placeholderProps]` covered only the default branch; the tag branch reads 7 additional values, so tag chips could render with stale `onClick` / `size` / `readOnly` / `disabled` state when the parent re-rendered with new props.

## Closes

Closes #561 (see the issue for symptoms, root cause, file:line citations, and reproduction notes).

## Test plan

- [x] `yarn lint` — clean
- [x] `yarn test` — 579 / 579 pass (no test changes; existing Textarea / RichTextEditor tests still green)
- [x] `yarn build:test:prod` — clean
- [x] Manually verified against toolkit-react `feature/dpql-editor` consuming this branch (built locally) — tag chip click handlers no longer stale after parent re-renders; no more `TypeError` on blur to browser chrome
- [ ] Reviewer should sanity-check the renderElement deps change against any in-repo consumer that passes inline arrow functions for `onTagClick` — those will see re-memoization on every render (correct behavior, but a perf consideration consumers should know about; the inline comment documents this)

## Notes

- Two fixes in one PR because they live next to each other in the editor stack and were both caught by the same toolkit-react integration. Happy to split if the maintainer would prefer two PRs.
- No API changes. The `renderElement` deps expansion is implementation-internal; consumers calling Reqore primitives don't see any signature change.
- No new tests added — the existing test suite passes and these are correctness fixes to runtime behavior that's hard to assert against in a unit test without a more invasive harness (would need to assert "the useCallback returned a fresh closure when X changed"). If the maintainer wants tests, happy to add a behavioral test that re-renders with changed `onTagClick` and verifies the chip's click handler is the new one.