### PR TITLE
chore(release): bump to 0.68.5 (re-fires release for PR #562 fixes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.68.4",
+  "version": "0.68.5",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Why

PR #562 (merged 2026-05-31) shipped two correctness fixes for `Textarea` + `RichTextEditor` but didn't bump the `package.json` version. The post-merge **Beta release** workflow ran and failed at the "Create a release" step:

```
Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}
```

…because the workflow tries to tag `v<package.json version>` and `v0.68.4` already exists from the previous release (before PR #562 merged). Source fix is on develop; no release / npm publish for it happened.

## What this does

Bumps `package.json` `0.68.4` → `0.68.5`. The post-merge release workflow will pick `v0.68.5` (fresh tag), succeed, and ship a release containing PR #562's fixes.

## What's in 0.68.5 vs 0.68.4

Just what PR #562 added:

- **`Textarea.handleBlur` null-safety** — guards `e.relatedTarget` against `null` (Escape / tab-switch / focus to browser chrome) so `.closest()` doesn't throw.
- **`RichTextEditor.renderElement` deps** — completes the `useCallback` deps array; tag chips no longer render with stale `onClick` / `size` / `readOnly` state when the parent re-renders.

## Test plan

- [x] `package.json` is the only change.
- [x] No code changes — Tests / CodeQL / DeepScan / Storybook Publish should all reproduce the green state from PR #562.
- [ ] After merge, confirm the **Beta release** workflow tags `v0.68.5` and publishes successfully (this is the actual point of the PR).