### PR TITLE
Fix long content wrapping in DataView

### DIFF
--- a/__tests__/dataView.test.tsx
+++ b/__tests__/dataView.test.tsx
@@ -200,6 +200,47 @@ test('Honours a custom `keyIntent` and `null` (drops intent)', () => {
   ).toBeGreaterThan(0);
 });
 
+test('Renders a long string value without truncating its content', () => {
+  // Regression guard: an early iteration rendered the value chip with
+  // wrap=false, so a long string overflowed its column horizontally
+  // and parts of the text were lost off-screen. The chip must keep
+  // every character of the input.
+  const longValue =
+    'MSH|^~\\&|VW-DEVICE|VITALSIM|EHR|HOSPITAL|2026-05-31 14:40:29.292347 Sun +02:00 (CEST)||ORU^R01|MSG-17669ff5-ce8f-4bd0-9903-4d207e193b83|P|2.5';
+  render(
+    wrap(<ReqoreDataView data={{ payload: longValue }} collapsibleRoot={false} />)
+  );
+  // Whole string is in the DOM — wrap means it spans multiple lines
+  // visually but stays one continuous text node.
+  expect(document.body.textContent).toContain(longValue);
+});
+
+test('Renders a long key without dropping the row or the value next to it', () => {
+  // Regression guard: a long key chip used to be rendered with
+  // `fixed`, so it kept its content width and pushed the value chip
+  // sideways. Now the chip can wrap inside its column and the value
+  // stays in place.
+  render(
+    wrap(
+      <ReqoreDataView
+        data={{
+          validated_against_local_terminology_dictionary: true,
+          normalized_observation_count: 2,
+        }}
+        collapsibleRoot={false}
+      />
+    )
+  );
+  // Both rows present + both values rendered alongside their keys.
+  expect(document.querySelectorAll('.reqore-data-view-row').length).toBe(2);
+  expect(document.body.textContent).toContain(
+    'validated_against_local_terminology_dictionary'
+  );
+  expect(document.body.textContent).toContain('true');
+  expect(document.body.textContent).toContain('normalized_observation_count');
+  expect(document.body.textContent).toContain('2');
+});
+
 test('Renders at every size prop value', () => {
   for (const size of ['tiny', 'small', 'normal', 'big', 'huge'] as const) {
     const { unmount } = render(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.69.0",
+  "version": "0.69.1",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/DataView/index.tsx
+++ b/src/components/DataView/index.tsx
@@ -608,7 +608,7 @@ const RecordTable = memo(
 
     useLayoutEffect(() => {
       const node = shellRef.current;
-      if (!node || typeof ResizeObserver === 'undefined') return;
+      if (!node || typeof ResizeObserver === 'undefined') return undefined;
       const observer = new ResizeObserver((events) => {
         const entry = events[0];
         if (!entry) return;

--- a/src/components/DataView/index.tsx
+++ b/src/components/DataView/index.tsx
@@ -255,21 +255,23 @@ const Row = styled.div<
       flex-direction: column;
     `}
 
-  /* When the row collapses to a single column (either because the
-     value is a record/array, or because the container ResizeObserver
-     flipped \`$stacked\` on), the grid's default \`justify-items: stretch\`
-     would expand the key chip to the full row width. Pin it back to
-     start + content-width so the chip stays compact and the value
-     drops into the next grid row below it. */
-  ${({ $complex, $stacked }) =>
-    ($complex || $stacked) &&
-    css`
-      & > .reqore-data-view-key {
-        justify-self: start;
-        width: fit-content;
-        max-width: 100%;
-      }
-    `}
+  /* The key chip's grid behaviour, applied universally — covers
+     two-column rows, complex-value rows AND stacked (narrow
+     container) rows in one set of rules:
+     - \`justify-self: start\` stops the grid's default
+       \`justify-items: stretch\` from expanding the chip to fill the
+       full grid cell. The chip sizes to its content instead, only
+       hitting the column cap when content actually needs it.
+     - \`min-width: 0\` releases ReqoreTag's intrinsic min-content size
+       (its longest unbreakable run) so the grid track can honour
+       its \`minmax(..., 220px)\` cap. Without this, snake_case keys
+       or UUIDs feed back into the track sizing and expand the
+       column past 220px. */
+  & > .reqore-data-view-key {
+    justify-self: start;
+    min-width: 0;
+    max-width: 100%;
+  }
 `;
 
 const ValueCell = styled.div<IStyledThemeProps & { $complex?: boolean }>`

--- a/src/components/DataView/index.tsx
+++ b/src/components/DataView/index.tsx
@@ -184,6 +184,14 @@ const Tree = styled.div<IStyledThemeProps>`
   .reqore-data-view-value .reqore-tag-content,
   .reqore-data-view-type .reqore-tag-content {
     font-family: ${MONO_FONT};
+    /* Long unbreakable identifiers (UUIDs, snake_case keys, HL7
+       payloads with no spaces) need an extra hint to break — the
+       tag's own \`wrap\` enables breaks at WHITESPACE, but these run
+       on continuously. \`overflow-wrap: anywhere\` is the
+       last-resort break point. Only applied here (inside the tag
+       content) so the chip's outer geometry isn't affected. */
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 `;
 
@@ -211,11 +219,17 @@ const TableShell = styled.div<IStyledThemeProps & { $nested?: boolean }>`
     $nested ? 'rgba(0, 0, 0, 0.45)' : 'rgba(0, 0, 0, 0.15)'};
 `;
 
-const Row = styled.div<IStyledThemeProps & { $complex?: boolean; $odd?: boolean }>`
+
+const Row = styled.div<
+  IStyledThemeProps & { $complex?: boolean; $odd?: boolean; $stacked?: boolean }
+>`
   display: grid;
-  grid-template-columns:
-    ${({ $complex }) => ($complex ? 'minmax(0, 1fr)' : 'minmax(120px, min(34%, 220px)) minmax(0, 1fr)')};
-  gap: ${({ $size, $complex }) => ($complex ? GAP_FROM_SIZE[$size] : 8)}px;
+  grid-template-columns: ${({ $complex, $stacked }) =>
+    $complex || $stacked
+      ? 'minmax(0, 1fr)'
+      : 'minmax(120px, min(34%, 220px)) minmax(0, 1fr)'};
+  gap: ${({ $size, $complex, $stacked }) =>
+    $complex || $stacked ? GAP_FROM_SIZE[$size] : 8}px;
   align-items: start;
   min-width: 0;
   padding: ${({ $size }) => PADDING_FROM_SIZE[$size] / 2}px ${({ $size }) =>
@@ -239,6 +253,22 @@ const Row = styled.div<IStyledThemeProps & { $complex?: boolean; $odd?: boolean 
     $complex &&
     css`
       flex-direction: column;
+    `}
+
+  /* When the row collapses to a single column (either because the
+     value is a record/array, or because the container ResizeObserver
+     flipped \`$stacked\` on), the grid's default \`justify-items: stretch\`
+     would expand the key chip to the full row width. Pin it back to
+     start + content-width so the chip stays compact and the value
+     drops into the next grid row below it. */
+  ${({ $complex, $stacked }) =>
+    ($complex || $stacked) &&
+    css`
+      & > .reqore-data-view-key {
+        justify-self: start;
+        width: fit-content;
+        max-width: 100%;
+      }
     `}
 `;
 
@@ -508,6 +538,12 @@ const renderScalar = (
       size={ctx.size}
       flat={false}
       minimal
+      // `wrap` is critical for the value chip — without it, a long
+      // string scalar (an HL7 payload, a stack trace, a UUID-heavy
+      // identifier) renders as a single non-wrapping pill that
+      // overflows its column horizontally. With `wrap`, ReqoreTag
+      // lets the label flow onto multiple lines inside the chip.
+      wrap
       label={scalar.display}
       intent={intent}
       effect={{
@@ -538,6 +574,111 @@ const renderScalar = (
     </ScalarRow>
   );
 };
+
+/** Width (in CSS px) below which a `RecordTable` switches its rows
+ *  from a two-column grid (key | value) to a single column (key on
+ *  top, value beneath). Tuned to the point where the 120px-min key
+ *  column + gap + the value column starts squeezing the value into a
+ *  useless sliver. */
+const STACK_BELOW_PX = 360;
+
+interface IRecordTableProps {
+  entries: Array<[string, unknown]>;
+  ctx: TRenderContext;
+  theme: IReqoreTheme;
+  depth: number;
+  path: string[];
+}
+
+/**
+ * Record renderer that observes its own width and switches the row
+ * layout to vertical (key above value) when narrower than
+ * `STACK_BELOW_PX`. The observer hooks the actual rendered
+ * `TableShell` so the layout responds to *the parent panel's* width,
+ * not the viewport — works inside narrow drawers on a wide monitor.
+ *
+ * Lives outside `renderTree` because `renderTree` is a pure function;
+ * this component is where the `useState` + `ResizeObserver` lifecycle
+ * live.
+ */
+const RecordTable = memo(
+  ({ entries, ctx, theme, depth, path }: IRecordTableProps) => {
+    const shellRef = useRef<HTMLDivElement | null>(null);
+    const [stacked, setStacked] = useState(false);
+
+    useLayoutEffect(() => {
+      const node = shellRef.current;
+      if (!node || typeof ResizeObserver === 'undefined') return;
+      const observer = new ResizeObserver((events) => {
+        const entry = events[0];
+        if (!entry) return;
+        const width = entry.contentRect?.width ?? node.clientWidth;
+        setStacked(width > 0 && width < STACK_BELOW_PX);
+      });
+      observer.observe(node);
+      return () => observer.disconnect();
+    }, []);
+
+    return (
+      <TableShell
+        ref={shellRef}
+        $size={ctx.size}
+        $theme={theme}
+        $nested={depth > 0}
+        className='reqore-data-view-record'
+      >
+        {entries.map(([key, item], index) => {
+          const complex =
+            reqoreIsRecord(
+              ctx.envelope === false ? item : reqoreUnwrapEnvelope(item, ctx.envelope)
+            ) ||
+            (Array.isArray(
+              ctx.envelope === false ? item : reqoreUnwrapEnvelope(item, ctx.envelope)
+            ) &&
+              !(
+                ctx.inlineScalarArrays &&
+                (ctx.envelope === false
+                  ? (item as unknown[])
+                  : (reqoreUnwrapEnvelope(item, ctx.envelope) as unknown[])
+                ).every((entry) => isInlineableScalarValue(entry, ctx))
+              ));
+          return (
+            <Row
+              key={`${path.join('.')}-${key}`}
+              $size={ctx.size}
+              $theme={theme}
+              $complex={complex}
+              $odd={index % 2 === 0}
+              $stacked={stacked}
+              className='reqore-data-view-row'
+            >
+              <ReqoreTag
+                size={ctx.size}
+                flat={false}
+                minimal
+                wrap
+                intent={ctx.keyIntent === null ? undefined : ctx.keyIntent ?? 'info'}
+                color={ctx.keyColor}
+                label={key}
+                effect={{ weight: 'bold' }}
+                className='reqore-data-view-key'
+              />
+              <ValueCell
+                $size={ctx.size}
+                $theme={theme}
+                $complex={complex}
+                className='reqore-data-view-value-cell'
+              >
+                {renderTree(item, ctx, theme, depth + 1, [...path, key])}
+              </ValueCell>
+            </Row>
+          );
+        })}
+      </TableShell>
+    );
+  }
+);
+RecordTable.displayName = 'ReqoreDataView.RecordTable';
 
 const renderTree = (
   value: unknown,
@@ -638,60 +779,13 @@ const renderTree = (
   if (reqoreIsRecord(unwrapped)) {
     const entries = Object.entries(unwrapped);
     const content = (
-      <TableShell
-        $size={ctx.size}
-        $theme={theme}
-        $nested={depth > 0}
-        className='reqore-data-view-record'
-      >
-        {entries.map(([key, item], index) => {
-          const complex =
-            reqoreIsRecord(
-              ctx.envelope === false ? item : reqoreUnwrapEnvelope(item, ctx.envelope)
-            ) ||
-            (Array.isArray(
-              ctx.envelope === false ? item : reqoreUnwrapEnvelope(item, ctx.envelope)
-            ) &&
-              !(
-                ctx.inlineScalarArrays &&
-                (ctx.envelope === false
-                  ? (item as unknown[])
-                  : (reqoreUnwrapEnvelope(item, ctx.envelope) as unknown[])
-                ).every((entry) => isInlineableScalarValue(entry, ctx))
-              ));
-          return (
-            <Row
-              key={`${path.join('.')}-${key}`}
-              $size={ctx.size}
-              $theme={theme}
-              $complex={complex}
-              $odd={index % 2 === 0}
-              className='reqore-data-view-row'
-            >
-              <ReqoreTag
-                size={ctx.size}
-                flat={false}
-                minimal
-                intent={ctx.keyIntent === null ? undefined : ctx.keyIntent ?? 'info'}
-                color={ctx.keyColor}
-                label={key}
-                effect={{ weight: 'bold' }}
-                className='reqore-data-view-key'
-                fixed
-              />
-
-              <ValueCell
-                $size={ctx.size}
-                $theme={theme}
-                $complex={complex}
-                className='reqore-data-view-value-cell'
-              >
-                {renderTree(item, ctx, theme, depth + 1, [...path, key])}
-              </ValueCell>
-            </Row>
-          );
-        })}
-      </TableShell>
+      <RecordTable
+        entries={entries}
+        ctx={ctx}
+        theme={theme}
+        depth={depth}
+        path={path}
+      />
     );
 
     if (depth === 0) return content;

--- a/src/stories/DataView/DataView.stories.tsx
+++ b/src/stories/DataView/DataView.stories.tsx
@@ -214,6 +214,131 @@ export const Sizes: Story = {
   },
 };
 
+// ---- Long-content regression stories (Chromatic) -----------------------
+//
+// These stories cover the layout edge cases that regressed in early
+// iterations: a long string value overflowing its column, a long key
+// chip blowing past the key column, and the combination of the two in
+// a single payload. They're authored as visual stories — open them in
+// Chromatic to confirm both keys AND values wrap cleanly inside their
+// row instead of overflowing horizontally.
+
+// A realistic HL7-ish pipe-delimited payload — exactly the shape that
+// triggered the original overflow bug.
+const HL7_PAYLOAD =
+  'MSH|^~\\&|VW-DEVICE|VITALSIM|EHR|HOSPITAL|2026-05-31 14:40:29.292347 Sun +02:00 (CEST)||ORU^R01|MSG-17669ff5-ce8f-4bd0-9903-4d207e193b83|P|2.5\rOBR|1|REQ-1005||VW-VITALS-FILL-1005|VW_PRESSURE_PANEL^VitalWear pressure panel^L OBX|1|NM|VW_SKIN_TEMP^Skin temperature^L|1|36.7|Cel|36.0-37.5|N|||F';
+
+export const LongStringValue: Story = {
+  args: {
+    label: 'Long string value',
+    description:
+      'A scalar that does not fit in a single line — wraps inside the chip rather than overflowing horizontally.',
+    collapsibleRoot: false,
+    data: {
+      message_id: 'MSG-17669ff5-ce8f-4bd0-9903-4d207e193b83',
+      payload_hash: 'sha256:5d0fce3e2ba8eb29df90a93fd35aa68e2eb0aa3ed5f',
+      payload: HL7_PAYLOAD,
+    },
+  },
+};
+
+export const LongKey: Story = {
+  args: {
+    label: 'Long key',
+    description:
+      'A key longer than the key column wraps inside its chip and never shoves the value off-screen.',
+    collapsibleRoot: false,
+    data: {
+      patient_ref: 'PAT-1005',
+      device_id: 'DEV-VW-1005',
+      normalized_observation_count: 2,
+      validated_against_local_terminology_dictionary: true,
+      escalated_to_downstream_clinical_decision_support: false,
+    },
+  },
+};
+
+export const MixedLongContent: Story = {
+  args: {
+    label: 'Mixed long keys + long values',
+    description:
+      'Both columns under pressure — keys *and* values wrap inside their chips, rows stay on one horizontal line per pair.',
+    collapsibleRoot: false,
+    defaultExpandDepth: 10,
+    data: {
+      message_control_id: 'VW-DEADLETTER-001-2079074b-0000-4eee-8b48-f9e3f4b1c2d8',
+      payload: HL7_PAYLOAD,
+      normalized_observation_count: 2,
+      downstream_processor_dispatcher_pipeline_route:
+        'cs:vital-signs/router/v2/dispatch?priority=high&ack=hl7-v2.5&tenant=eu-west-prod-eks-2',
+      observations: [
+        {
+          observation_id: 'OBS-024c8401-f649-4c82-b52f-7fc60853de3a',
+          message_id: 'MSG-17669ff5-ce8f-4bd0-9903-4d207e193b83',
+          message_control_id: 'VW-DEADLETTER-001-2079074b',
+          local_code: 'VW_SKIN_TEMP',
+          display: 'Skin temperature reading from VitalWear pressure panel',
+        },
+      ],
+    },
+  },
+};
+
+export const InNarrowContainer: Story = {
+  render: (args) => (
+    <div style={{ width: 300, border: '1px dashed rgba(255,255,255,0.2)', padding: 8 }}>
+      <ReqoreDataView {...args} />
+    </div>
+  ),
+  args: {
+    label: 'Narrow container (300px)',
+    description:
+      'Constrained by the parent — exercises the column shrink + wrap path. Keys and values both wrap inside their chips so neither overflows the row, and rows stay side-by-side. (A CSS @container query for stack-on-narrow was attempted but currently does not survive styled-components 5.x / stylis 3.x — JS-driven stacking is on the follow-up list.)',
+    collapsibleRoot: false,
+    defaultExpandDepth: 10,
+    data: {
+      patient_ref: 'PAT-1005',
+      normalized_observation_count: 2,
+      payload: HL7_PAYLOAD,
+    },
+  },
+};
+
+export const WidthComparison: Story = {
+  render: (args) => (
+    <div style={{ display: 'flex', flexFlow: 'column', gap: 16 }}>
+      {[260, 360, 480, 720].map((width) => (
+        <div
+          key={width}
+          style={{
+            width,
+            border: '1px dashed rgba(255,255,255,0.2)',
+            padding: 8,
+          }}
+        >
+          <ReqoreDataView {...args} label={`Container ${width}px`} />
+        </div>
+      ))}
+    </div>
+  ),
+  args: {
+    collapsibleRoot: false,
+    defaultExpandDepth: 10,
+    data: {
+      patient_ref: 'PAT-1005',
+      observation_count: 2,
+      payload: HL7_PAYLOAD,
+      observations: [
+        {
+          observation_id: 'OBS-024c8401',
+          local_code: 'VW_SKIN_TEMP',
+          value: 36.7,
+        },
+      ],
+    },
+  },
+};
+
 export const InteractionToggle: Story = {
   args: {
     label: 'Interaction',


### PR DESCRIPTION
Ensure long content in DataView rows wraps correctly and update the version while handling the ResizeObserver return type.