### PR TITLE
feat(link): add ReqoreLink + fix(panel): footer-stranding min-height + fix(error-boundary): log caught errors

### DIFF
--- a/__tests__/errorBoundary.test.tsx
+++ b/__tests__/errorBoundary.test.tsx
@@ -1,0 +1,46 @@
+import { render } from '@testing-library/react';
+import { ReqoreErrorBoundary, ReqoreUIProvider } from '../src';
+
+// A child that always throws during render so the boundary catches it.
+const Boom = () => {
+  throw new Error('boom-from-child');
+};
+
+const renderBoundary = () =>
+  render(
+    <ReqoreUIProvider>
+      <ReqoreErrorBoundary>
+        <Boom />
+      </ReqoreErrorBoundary>
+    </ReqoreUIProvider>
+  );
+
+test('ReqoreErrorBoundary logs the caught error to the console', () => {
+  // React also logs caught errors in jsdom/dev; mute the noise but capture calls
+  // so we can assert our own log fired (in a production build React stays quiet,
+  // which is exactly why the boundary must log itself).
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  try {
+    renderBoundary();
+
+    const logged = spy.mock.calls.some(
+      (args) =>
+        typeof args[0] === 'string' &&
+        args[0].includes('ReqoreErrorBoundary caught an error') &&
+        args.some((a) => a instanceof Error && a.message === 'boom-from-child')
+    );
+    expect(logged).toBe(true);
+  } finally {
+    spy.mockRestore();
+  }
+});
+
+test('ReqoreErrorBoundary still renders a visible fallback when a child throws', () => {
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  try {
+    const { getByText } = renderBoundary();
+    expect(getByText('Something went wrong')).toBeTruthy();
+  } finally {
+    spy.mockRestore();
+  }
+});

--- a/__tests__/link.test.tsx
+++ b/__tests__/link.test.tsx
@@ -61,3 +61,35 @@ test('Disabled <Link href> drops the href so it cannot navigate', () => {
   expect(link.getAttribute('href')).toBeNull();
   expect(link.getAttribute('aria-disabled')).toBe('true');
 });
+
+test('Renders a leading icon when `icon` is provided', () => {
+  renderLink(
+    <ReqoreLink href='https://example.com' icon='ExternalLinkLine'>
+      Docs
+    </ReqoreLink>
+  );
+
+  const link = document.querySelector('a.reqore-link') as HTMLAnchorElement;
+  expect(link).toBeTruthy();
+  expect(link.querySelector('.reqore-icon')).toBeTruthy();
+  expect(link.textContent).toContain('Docs');
+});
+
+test('Renders a custom element via `as` and passes element props through', () => {
+  const RouterLinkStub = ({ to, children, ...rest }: any) => (
+    <a href={to} data-router-link {...rest}>
+      {children}
+    </a>
+  );
+
+  renderLink(
+    <ReqoreLink as={RouterLinkStub} to='/issues'>
+      Issues
+    </ReqoreLink>
+  );
+
+  const link = document.querySelector('a.reqore-link') as HTMLAnchorElement;
+  expect(link).toBeTruthy();
+  expect(link.getAttribute('href')).toBe('/issues');
+  expect(link.hasAttribute('data-router-link')).toBe(true);
+});

--- a/__tests__/link.test.tsx
+++ b/__tests__/link.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render } from '@testing-library/react';
+import { ReqoreContent, ReqoreLayoutContent, ReqoreLink, ReqoreUIProvider } from '../src';
+
+const renderLink = (ui: React.ReactNode) =>
+  render(
+    <ReqoreUIProvider>
+      <ReqoreLayoutContent>
+        <ReqoreContent>{ui}</ReqoreContent>
+      </ReqoreLayoutContent>
+    </ReqoreUIProvider>
+  );
+
+test('Renders <Link /> as a button by default and fires onClick', () => {
+  const onClick = jest.fn();
+  renderLink(<ReqoreLink onClick={onClick}>Open issue list</ReqoreLink>);
+
+  const link = document.querySelector('button.reqore-link');
+  expect(link).toBeTruthy();
+
+  fireEvent.click(link!);
+  expect(onClick).toHaveBeenCalledTimes(1);
+});
+
+test('Renders <Link href> as an anchor with the URL + new-tab rel', () => {
+  renderLink(
+    <ReqoreLink href='https://example.com' external>
+      Docs
+    </ReqoreLink>
+  );
+
+  const link = document.querySelector('a.reqore-link') as HTMLAnchorElement | null;
+  expect(link).toBeTruthy();
+  expect(link!.getAttribute('href')).toBe('https://example.com');
+  expect(link!.getAttribute('target')).toBe('_blank');
+  expect(link!.getAttribute('rel')).toBe('noopener noreferrer');
+});
+
+test('Disabled <Link> renders a disabled button that does not fire onClick', () => {
+  const onClick = jest.fn();
+  renderLink(
+    <ReqoreLink onClick={onClick} disabled>
+      Disabled
+    </ReqoreLink>
+  );
+
+  const link = document.querySelector('button.reqore-link') as HTMLButtonElement;
+  expect(link.disabled).toBe(true);
+
+  fireEvent.click(link);
+  expect(onClick).not.toHaveBeenCalled();
+});
+
+test('Disabled <Link href> drops the href so it cannot navigate', () => {
+  renderLink(
+    <ReqoreLink href='https://example.com' disabled>
+      Docs
+    </ReqoreLink>
+  );
+
+  const link = document.querySelector('a.reqore-link') as HTMLAnchorElement;
+  expect(link.getAttribute('href')).toBeNull();
+  expect(link.getAttribute('aria-disabled')).toBe('true');
+});

--- a/__tests__/panel.test.tsx
+++ b/__tests__/panel.test.tsx
@@ -313,3 +313,34 @@ test('Renders <Panel /> with default iconVerticalAlign=center', () => {
 
   expect(document.querySelectorAll('.reqore-panel-title').length).toBe(1);
 });
+
+test('Panel content area carries min-height:0 so a tall body scrolls instead of stranding the footer', () => {
+  render(
+    <div style={{ width: '1000px' }}>
+      <ReqoreUIProvider>
+        <ReqoreLayoutContent>
+          <ReqorePanel label='Test' bottomActions={[{ label: 'Save', position: 'right' }]}>
+            Panel body
+          </ReqorePanel>
+        </ReqoreLayoutContent>
+      </ReqoreUIProvider>
+    </div>
+  );
+
+  const content = document.querySelector('.reqore-panel-content');
+  expect(content).toBeTruthy();
+
+  // styled-components (v5, test mode) injects readable CSS into <style> tags.
+  const css = Array.from(document.querySelectorAll('style'))
+    .map((style) => style.textContent || '')
+    .join('\n');
+
+  // One of the content element's styled-components classes must carry the
+  // `min-height: 0` declaration. Without it a flex child can't shrink below its
+  // content size, so a tall body pushes the (flex: 0 0 auto) bottom-actions
+  // footer past the panel's clipped edge instead of scrolling.
+  const hasMinHeightRule = Array.from(content!.classList).some((cls) =>
+    new RegExp(`\\.${cls}[^{}]*\\{[^}]*min-height:\\s*0`).test(css)
+  );
+  expect(hasMinHeightRule).toBe(true);
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.69.1",
+  "version": "0.69.2",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/COMPONENTS.md
+++ b/src/components/COMPONENTS.md
@@ -33,6 +33,7 @@
 | **ReqoreKeyValueTable** | Table displaying key-value pairs with optional sorting, filtering, and custom renderers. |
 | **ReqoreLabel** | Label element wrapper that extends ReqoreTag for form field labels. |
 | **ReqoreLayoutWrapper** | Root layout container providing flex layout structure and theme context for the entire application. |
+| **ReqoreLink** | Inline, themeable, keyboard-accessible text link. Renders a real `<a href>` when given `href` (so middle-click / open-in-new-tab work; `external` adds `target="_blank"` + a safe `rel`) or a `<button type="button">` when given `onClick` — the same affordance whether the link navigates or triggers an in-app action. Flows `inline` by default (`inline={false}` for an `inline-flex` row with an icon child), `underline` toggles the underline, and it supports the standard prop set: `intent` (colours the text), `size`, `customTheme`, `effect`, `tooltip`, and `disabled` (dimmed + non-interactive; drops the `href`). Use it for clickable text inside a sentence or list where `ReqoreButton` (a block control) would break the line. |
 | **ReqoreMenu** | Vertical menu container with support for resizing, customizable item gaps, and menu styling. |
 | **ReqoreMessage** | Notification/alert message component with optional icon, title, auto-dismiss, and click handlers. Optional `raised` adds a subtle 3D inset highlight when paired with `flat` (suppressed for `minimal` messages). |
 | **ReqoreModal** | Modal dialog that extends Drawer with centered positioning and ESC key handling. |

--- a/src/components/Effect/index.tsx
+++ b/src/components/Effect/index.tsx
@@ -557,7 +557,11 @@ ${({ effect }: IReqoreTextEffectProps) =>
     `};
 `;
 
-export const StyledTextEffect = styled(StyledEffect).attrs((props) => ({ ...props, isText: true }))`
+// `attrs` only needs to add `isText` — styled-components already forwards all
+// other props. Spreading `...props` here re-injects `className`, which styled-
+// components then concatenates on top of the prop className, duplicating any
+// custom class (e.g. `reqore-link` / `reqore-span`) on every text-effect element.
+export const StyledTextEffect = styled(StyledEffect).attrs({ isText: true })`
   display: ${({ inline, block }) => (inline ? 'inline' : block ? 'block' : 'inline-block')};
 
   ${({ effect }: IReqoreTextEffectProps) =>

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -27,6 +27,13 @@ export class ErrorBoundary extends Component<IReqoreErrorBoundaryProps, IReqoreE
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
+    // React only auto-logs caught errors in development builds; in a
+    // production build a caught error otherwise produces no console output at
+    // all (only the visual fallback renders), which makes swallowed
+    // exceptions impossible to debug. Always log so the error stays visible.
+    // eslint-disable-next-line no-console
+    console.error('ReqoreErrorBoundary caught an error:', error, info?.componentStack);
+
     this.props.onError?.(error, info);
   }
 

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, memo, MouseEvent } from 'react';
 import styled from 'styled-components';
-import { TEXT_FROM_SIZE, TSizes } from '../../constants/sizes';
+import { PADDING_FROM_SIZE, TEXT_FROM_SIZE, TSizes } from '../../constants/sizes';
 import { changeLightness } from '../../helpers/colors';
 import { isStringSize } from '../../helpers/utils';
 import { useReqoreTheme } from '../../hooks/useTheme';
@@ -10,7 +10,10 @@ import {
   IWithReqoreEffect,
   IWithReqoreTooltip,
 } from '../../types/global';
-import { StyledTextEffect } from '../Effect';
+import { IReqoreIconName } from '../../types/icons';
+import { TReqoreEffectColor } from '../Effect';
+import ReqoreIcon from '../Icon';
+import { StyledSpan } from '../Span';
 import { ReqoreTooltipComponent } from '../TooltipComponent';
 
 export interface IReqoreLinkProps
@@ -19,9 +22,9 @@ export interface IReqoreLinkProps
     IWithReqoreEffect,
     IReqoreIntent,
     IWithReqoreTooltip {
-  /** Render an anchor to this URL. When omitted an `onClick`-driven
-   *  `<button type="button">` is rendered instead, so the link works the
-   *  same whether it navigates or triggers an in-app action. */
+  /** Render an anchor to this URL. When omitted (and no custom `as` is given)
+   *  an `onClick`-driven `<button type="button">` is rendered instead, so the
+   *  link works the same whether it navigates or triggers an in-app action. */
   href?: string;
   /** Open an `href` link in a new tab (adds `rel="noopener noreferrer"`). */
   external?: boolean;
@@ -29,9 +32,22 @@ export interface IReqoreLinkProps
   disabled?: boolean;
   /** Underline the text. Defaults to `true`. */
   underline?: boolean;
-  /** Flow inline (default) or render as an `inline-flex` row (e.g. with an
-   *  icon child). */
+  /** Leading icon, rendered before the text. Setting an icon switches the link
+   *  to an `inline-flex` row so the icon and text stay vertically centered. */
+  icon?: IReqoreIconName;
+  /** Color for the `icon`. Defaults to the link's (intent) text color. */
+  iconColor?: TReqoreEffectColor;
+  /** Flow inline (default) or render as an `inline-flex` row. Forced on when an
+   *  `icon` is set. */
   inline?: boolean;
+  /**
+   * Render a custom element instead of the default `<a>` / `<button>` — e.g. a
+   * router's link component (`as={Link}` with `to="..."` for react-router, or
+   * `as={NextLink} href="..."` for Next.js). Element-specific props (`to`,
+   * `href`, …) are passed straight through. When set, the element is treated as
+   * link-like (it receives `external`/`disabled` handling like an anchor).
+   */
+  as?: string | React.ElementType;
   size?: TSizes | string;
   onClick?: (event: MouseEvent<HTMLElement>) => void;
 }
@@ -42,10 +58,15 @@ interface IReqoreLinkStyle {
   $inline?: boolean;
 }
 
-export const StyledLink = styled(StyledTextEffect)<IReqoreLinkStyle>`
+// Built on top of `StyledSpan` so the color / intent / text-effect resolution
+// lives in one place (the Span primitive); only the interactive link-specific
+// styling is declared here.
+export const StyledLink = styled(StyledSpan)<IReqoreLinkStyle>`
   display: ${({ $inline }) => ($inline === false ? 'inline-flex' : 'inline')};
   align-items: center;
-  gap: 4px;
+  // Icon/text spacing scales with size (matches ReqoreButton's icon spacer);
+  // custom/undefined sizes fall back to 'normal', like the rendered icon does.
+  gap: ${({ _size }) => PADDING_FROM_SIZE[isStringSize(_size) ? _size : 'normal'] / 2}px;
   appearance: none;
   border: 0;
   margin: 0;
@@ -55,12 +76,16 @@ export const StyledLink = styled(StyledTextEffect)<IReqoreLinkStyle>`
   font-weight: inherit;
   font-size: ${({ _size }) =>
     _size ? (isStringSize(_size) ? `${TEXT_FROM_SIZE[_size]}px` : _size) : 'inherit'};
-  color: ${({ theme, intent }) => (intent ? theme.intents[intent] : theme.text?.color || 'inherit')};
   text-align: left;
   cursor: pointer;
-  text-decoration: ${({ $underline }) => ($underline === false ? 'none' : 'underline')};
-  text-decoration-thickness: 1px;
-  text-underline-offset: 3px;
+  /* Doubled selector raises specificity above the Layout's global
+     '.layout a { text-decoration: none }' reset, which would otherwise
+     strip the underline from the anchor variant. */
+  && {
+    text-decoration: ${({ $underline }) => ($underline === false ? 'none' : 'underline')};
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+  }
   transition:
     opacity 0.15s ease,
     color 0.15s ease;
@@ -87,11 +112,11 @@ export const StyledLink = styled(StyledTextEffect)<IReqoreLinkStyle>`
 
 /**
  * An inline, themeable, keyboard-accessible text link. Renders a real
- * `<a href>` when given `href` (so middle-click / open-in-new-tab work) or a
+ * `<a href>` when given `href` (so middle-click / open-in-new-tab work), a
  * `<button type="button">` when given `onClick` — the same affordance whether
- * the link navigates or triggers an in-app action. Use it for clickable text
- * that must flow inside a sentence or list, where `ReqoreButton` (a block
- * control) would break the line.
+ * the link navigates or triggers an in-app action — or a custom element via
+ * `as` (e.g. a router link). Use it for clickable text that must flow inside a
+ * sentence or list, where `ReqoreButton` (a block control) would break the line.
  */
 export const ReqoreLink = memo(
   forwardRef<HTMLElement, IReqoreLinkProps>(
@@ -108,6 +133,9 @@ export const ReqoreLink = memo(
         disabled,
         underline = true,
         inline = true,
+        icon,
+        iconColor,
+        as,
         onClick,
         tooltip,
         ...props
@@ -116,11 +144,19 @@ export const ReqoreLink = memo(
     ) => {
       const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
 
-      const isAnchor = href !== undefined;
-      const elementProps = isAnchor
+      // An icon needs the inline-flex row so it stays centered with the text.
+      const renderInline = icon ? false : inline;
+
+      // A custom element (router link, etc.) is treated as link-like; the
+      // intrinsic `<button>` is only used when there is no `as` and no `href`.
+      const isLinkLike = as !== undefined || href !== undefined;
+      const elementProps = isLinkLike
         ? {
-            as: 'a' as const,
-            href: disabled ? undefined : href,
+            as: as ?? ('a' as const),
+            // Only forward `href` when one is actually supplied — a custom `as`
+            // (e.g. a router link) derives its own href from `to` and would be
+            // broken by an injected `href={undefined}`.
+            ...(href !== undefined ? { href: disabled ? undefined : href } : {}),
             target: external ? '_blank' : undefined,
             rel: external ? 'noopener noreferrer' : undefined,
             'aria-disabled': disabled || undefined,
@@ -144,10 +180,18 @@ export const ReqoreLink = memo(
           ref={ref}
           tooltip={tooltip}
           _size={size}
-          $inline={inline}
+          $inline={renderInline}
           $underline={underline}
           className={`${className || ''} reqore-link`}
         >
+          {icon ? (
+            <ReqoreIcon
+              icon={icon}
+              size={isStringSize(size) ? (size as TSizes) : 'normal'}
+              intent={intent}
+              color={iconColor}
+            />
+          ) : null}
           {children}
         </ReqoreTooltipComponent>
       );

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -1,0 +1,160 @@
+import { forwardRef, memo, MouseEvent } from 'react';
+import styled from 'styled-components';
+import { TEXT_FROM_SIZE, TSizes } from '../../constants/sizes';
+import { changeLightness } from '../../helpers/colors';
+import { isStringSize } from '../../helpers/utils';
+import { useReqoreTheme } from '../../hooks/useTheme';
+import {
+  IReqoreIntent,
+  IWithReqoreCustomTheme,
+  IWithReqoreEffect,
+  IWithReqoreTooltip,
+} from '../../types/global';
+import { StyledTextEffect } from '../Effect';
+import { ReqoreTooltipComponent } from '../TooltipComponent';
+
+export interface IReqoreLinkProps
+  extends Omit<React.HTMLAttributes<HTMLElement>, 'color'>,
+    IWithReqoreCustomTheme,
+    IWithReqoreEffect,
+    IReqoreIntent,
+    IWithReqoreTooltip {
+  /** Render an anchor to this URL. When omitted an `onClick`-driven
+   *  `<button type="button">` is rendered instead, so the link works the
+   *  same whether it navigates or triggers an in-app action. */
+  href?: string;
+  /** Open an `href` link in a new tab (adds `rel="noopener noreferrer"`). */
+  external?: boolean;
+  /** Disable the link — non-interactive and dimmed. */
+  disabled?: boolean;
+  /** Underline the text. Defaults to `true`. */
+  underline?: boolean;
+  /** Flow inline (default) or render as an `inline-flex` row (e.g. with an
+   *  icon child). */
+  inline?: boolean;
+  size?: TSizes | string;
+  onClick?: (event: MouseEvent<HTMLElement>) => void;
+}
+
+interface IReqoreLinkStyle {
+  _size?: TSizes | string;
+  $underline?: boolean;
+  $inline?: boolean;
+}
+
+export const StyledLink = styled(StyledTextEffect)<IReqoreLinkStyle>`
+  display: ${({ $inline }) => ($inline === false ? 'inline-flex' : 'inline')};
+  align-items: center;
+  gap: 4px;
+  appearance: none;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  font-family: inherit;
+  font-weight: inherit;
+  font-size: ${({ _size }) =>
+    _size ? (isStringSize(_size) ? `${TEXT_FROM_SIZE[_size]}px` : _size) : 'inherit'};
+  color: ${({ theme, intent }) => (intent ? theme.intents[intent] : theme.text?.color || 'inherit')};
+  text-align: left;
+  cursor: pointer;
+  text-decoration: ${({ $underline }) => ($underline === false ? 'none' : 'underline')};
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease;
+
+  &:hover {
+    opacity: 0.82;
+  }
+
+  &:focus-visible {
+    outline: 2px solid
+      ${({ theme, intent }) => changeLightness(intent ? theme.intents[intent] : theme.main, 0.2)};
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  &:disabled,
+  &[aria-disabled='true'] {
+    cursor: default;
+    text-decoration: none;
+    opacity: 0.55;
+    pointer-events: none;
+  }
+`;
+
+/**
+ * An inline, themeable, keyboard-accessible text link. Renders a real
+ * `<a href>` when given `href` (so middle-click / open-in-new-tab work) or a
+ * `<button type="button">` when given `onClick` — the same affordance whether
+ * the link navigates or triggers an in-app action. Use it for clickable text
+ * that must flow inside a sentence or list, where `ReqoreButton` (a block
+ * control) would break the line.
+ */
+export const ReqoreLink = memo(
+  forwardRef<HTMLElement, IReqoreLinkProps>(
+    (
+      {
+        size,
+        children,
+        customTheme,
+        inheritCustomTheme,
+        intent,
+        className,
+        href,
+        external,
+        disabled,
+        underline = true,
+        inline = true,
+        onClick,
+        tooltip,
+        ...props
+      },
+      ref
+    ) => {
+      const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
+
+      const isAnchor = href !== undefined;
+      const elementProps = isAnchor
+        ? {
+            as: 'a' as const,
+            href: disabled ? undefined : href,
+            target: external ? '_blank' : undefined,
+            rel: external ? 'noopener noreferrer' : undefined,
+            'aria-disabled': disabled || undefined,
+            onClick: disabled ? (event: MouseEvent<HTMLElement>) => event.preventDefault() : onClick,
+          }
+        : {
+            as: 'button' as const,
+            type: 'button' as const,
+            disabled,
+            onClick,
+          };
+
+      return (
+        <ReqoreTooltipComponent
+          {...props}
+          {...elementProps}
+          theme={theme}
+          color={theme.text.color}
+          intent={intent}
+          Component={StyledLink}
+          ref={ref}
+          tooltip={tooltip}
+          _size={size}
+          $inline={inline}
+          $underline={underline}
+          className={`${className || ''} reqore-link`}
+        >
+          {children}
+        </ReqoreTooltipComponent>
+      );
+    }
+  )
+);
+
+ReqoreLink.displayName = 'ReqoreLink';
+
+export default ReqoreLink;

--- a/src/components/Panel/index.tsx
+++ b/src/components/Panel/index.tsx
@@ -514,6 +514,11 @@ export const StyledPanelContent = styled.div<IStyledPanel>`
       ? `${getPaddingSize(padded, size)}px 0`
       : `${getPaddingSize(padded, size)}px ${getPaddingSize(padded, size)}px`};
   flex: 1;
+  /* A flex child's min-height defaults to its content size, so without this the
+     scrollable content can't shrink: a panel/drawer body taller than the panel
+     pushes the (flex: 0 0 auto) bottom-actions footer past the panel's clipped
+     edge and strands it, instead of scrolling. */
+  min-height: 0;
   overflow: auto;
   overflow-wrap: anywhere;
   font-size: ${({ size }) => TEXT_FROM_SIZE[size]}px;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -56,6 +56,8 @@ export { default as ReqoreInput } from './components/Input';
 export { ReqoreKeyValueTable } from './components/KeyValueTable';
 export * from './components/Label';
 export { default as ReqoreLayoutContent } from './components/Layout/content';
+export { default as ReqoreLink } from './components/Link';
+export type { IReqoreLinkProps } from './components/Link';
 export { default as ReqoreMenu } from './components/Menu';
 export { default as ReqoreMenuDivider } from './components/Menu/divider';
 export { default as ReqoreMenuItem } from './components/Menu/item';

--- a/src/stories/Link/Link.stories.tsx
+++ b/src/stories/Link/Link.stories.tsx
@@ -16,20 +16,35 @@ type Story = StoryObj<typeof meta>;
 
 const onClick = jest.fn();
 
-/** Button mode — no `href`, so an `onClick`-driven `<button>` is rendered. */
+/** Default — given `href`, a real `<a>` is rendered (so middle-click /
+ *  open-in-new-tab work). */
 export const Default: Story = {
+  render: () => (
+    <ReqoreLink href='https://reqore.qoretechnologies.com'>reqore docs</ReqoreLink>
+  ),
+  play: async ({ canvasElement }) => {
+    const link = within(canvasElement).getByText('reqore docs') as HTMLAnchorElement;
+    await expect(link.tagName).toBe('A');
+    await expect(link.getAttribute('href')).toBe('https://reqore.qoretechnologies.com');
+  },
+};
+
+/** Button mode — with no `href` (and no custom `as`), an `onClick`-driven
+ *  `<button type="button">` is rendered, so the link triggers an in-app action
+ *  while still flowing as inline text. */
+export const LinkAsButton: Story = {
   render: () => <ReqoreLink onClick={onClick}>Open issue list →</ReqoreLink>,
   play: async ({ canvasElement }) => {
     onClick.mockClear();
-    const link = within(canvasElement).getByText('Open issue list →');
+    const link = within(canvasElement).getByText('Open issue list →') as HTMLButtonElement;
+    await expect(link.tagName).toBe('BUTTON');
     await fireEvent.click(link);
     await expect(onClick).toHaveBeenCalledTimes(1);
   },
 };
 
-/** Anchor mode — given `href`, a real `<a>` is rendered (`external` opens a
- *  new tab with a safe `rel`). */
-export const Anchor: Story = {
+/** External `href` opens a new tab with a safe `rel`. */
+export const External: Story = {
   render: () => (
     <ReqoreLink href='https://reqore.qoretechnologies.com' external>
       reqore docs
@@ -37,10 +52,26 @@ export const Anchor: Story = {
   ),
   play: async ({ canvasElement }) => {
     const link = within(canvasElement).getByText('reqore docs') as HTMLAnchorElement;
-    await expect(link.getAttribute('href')).toBe('https://reqore.qoretechnologies.com');
     await expect(link.getAttribute('target')).toBe('_blank');
     await expect(link.getAttribute('rel')).toBe('noopener noreferrer');
   },
+};
+
+/** A leading `icon` renders before the text and centers with it. */
+export const WithIcon: Story = {
+  render: () => (
+    <ReqoreControlGroup vertical>
+      <ReqoreLink href='https://reqore.qoretechnologies.com' external icon='ExternalLinkLine'>
+        reqore docs
+      </ReqoreLink>
+      <ReqoreLink onClick={noop} icon='ArrowRightLine' intent='info'>
+        Open issue list
+      </ReqoreLink>
+      <ReqoreLink onClick={noop} icon='ArrowRightLine' intent='info' size='huge'>
+        Larger link — icon, text and gap all scale with size
+      </ReqoreLink>
+    </ReqoreControlGroup>
+  ),
 };
 
 /** Intents colour the link via the standard theme intents. */
@@ -84,4 +115,26 @@ export const Disabled: Story = {
       Disabled link
     </ReqoreLink>
   ),
+};
+
+/** Custom element via `as` — e.g. a router link. Here a stand-in component
+ *  receives a `to` prop, the same way `react-router`'s `<Link>` would. */
+const RouterLinkStub = ({ to, children, ...rest }: any) => (
+  <a href={to} data-router-link {...rest}>
+    {children}
+  </a>
+);
+
+export const AsRouterLink: Story = {
+  render: () => (
+    <ReqoreLink as={RouterLinkStub} to='/issues'>
+      Go to issues
+    </ReqoreLink>
+  ),
+  play: async ({ canvasElement }) => {
+    const link = within(canvasElement).getByText('Go to issues') as HTMLAnchorElement;
+    await expect(link.tagName).toBe('A');
+    await expect(link.getAttribute('href')).toBe('/issues');
+    await expect(link.hasAttribute('data-router-link')).toBe(true);
+  },
 };

--- a/src/stories/Link/Link.stories.tsx
+++ b/src/stories/Link/Link.stories.tsx
@@ -1,0 +1,87 @@
+import { expect, jest } from '@storybook/jest';
+import { StoryObj } from '@storybook/react';
+import { fireEvent, within } from '@storybook/testing-library';
+import { noop } from 'lodash';
+import ReqoreLink from '../../components/Link';
+import { ReqoreControlGroup, ReqoreP } from '../../index';
+import { StoryMeta } from '../utils';
+
+const meta = {
+  title: 'Navigation/Link/Stories',
+  component: ReqoreLink,
+} as StoryMeta<typeof ReqoreLink>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const onClick = jest.fn();
+
+/** Button mode — no `href`, so an `onClick`-driven `<button>` is rendered. */
+export const Default: Story = {
+  render: () => <ReqoreLink onClick={onClick}>Open issue list →</ReqoreLink>,
+  play: async ({ canvasElement }) => {
+    onClick.mockClear();
+    const link = within(canvasElement).getByText('Open issue list →');
+    await fireEvent.click(link);
+    await expect(onClick).toHaveBeenCalledTimes(1);
+  },
+};
+
+/** Anchor mode — given `href`, a real `<a>` is rendered (`external` opens a
+ *  new tab with a safe `rel`). */
+export const Anchor: Story = {
+  render: () => (
+    <ReqoreLink href='https://reqore.qoretechnologies.com' external>
+      reqore docs
+    </ReqoreLink>
+  ),
+  play: async ({ canvasElement }) => {
+    const link = within(canvasElement).getByText('reqore docs') as HTMLAnchorElement;
+    await expect(link.getAttribute('href')).toBe('https://reqore.qoretechnologies.com');
+    await expect(link.getAttribute('target')).toBe('_blank');
+    await expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+  },
+};
+
+/** Intents colour the link via the standard theme intents. */
+export const Intents: Story = {
+  render: () => (
+    <ReqoreControlGroup vertical>
+      <ReqoreLink onClick={noop}>Default link</ReqoreLink>
+      <ReqoreLink intent='info' onClick={noop}>
+        Info link
+      </ReqoreLink>
+      <ReqoreLink intent='success' onClick={noop}>
+        Success link
+      </ReqoreLink>
+      <ReqoreLink intent='warning' onClick={noop}>
+        Warning link
+      </ReqoreLink>
+      <ReqoreLink intent='danger' onClick={noop}>
+        Danger link
+      </ReqoreLink>
+      <ReqoreLink intent='muted' onClick={noop}>
+        Muted link
+      </ReqoreLink>
+    </ReqoreControlGroup>
+  ),
+};
+
+/** Flows inline inside running text. */
+export const InProse: Story = {
+  render: () => (
+    <ReqoreP>
+      Previewing 8 of 12 active issues ·{' '}
+      <ReqoreLink onClick={noop}>Open issue list →</ReqoreLink>
+    </ReqoreP>
+  ),
+};
+
+/** Disabled — dimmed and non-interactive. */
+export const Disabled: Story = {
+  render: () => (
+    <ReqoreLink disabled onClick={noop}>
+      Disabled link
+    </ReqoreLink>
+  ),
+};


### PR DESCRIPTION
Three independent changes (kept on one branch per request).

## 1. `ReqoreLink` — inline link primitive

Adds **`ReqoreLink`**, an inline, themeable, keyboard-accessible text link — the library had none (`ReqoreButton` is a block control that breaks the line inline). Polymorphic: `href` → real `<a href>` (middle-click / open-in-new-tab; `external` adds `target=_blank` + safe `rel`); `onClick` → `<button type="button">`. Modeled on `ReqoreP`, so it supports `intent` / `size` / `customTheme` / `effect` / `tooltip` / `disabled`, plus `inline` vs `inline-flex` and an `underline` toggle. Story (`Navigation/Link`), jest tests, barrel export, `COMPONENTS.md` row.

## 2. `fix(panel)` — content area `min-height: 0` (footer-stranding)

`ReqorePanel` (and thus `ReqoreDrawer`) is a clipped flex column: header `flex: 0 0 auto` / content `flex: 1; overflow: auto` / bottom-actions footer `flex: 0 0 auto`. The content area was missing **`min-height: 0`**, so the flex child couldn't shrink below its content size — a body taller than the panel **grew instead of scrolling** and pushed the footer past the panel's `overflow: hidden` edge, **stranding it** (still in the DOM, just clipped). That's why opening a tall overlay/picker over a drawer made its Cancel/Save footer vanish until the drawer remounted.

Fix: add `min-height: 0` so `overflow: auto` scrolls and the footer stays pinned — fixes footer-stranding for **every** panel/drawer. Regression test asserts the rule is present (and fails without it).

## 3. `fix(error-boundary)` — log caught errors

`ReqoreErrorBoundary.componentDidCatch` only forwarded to an optional `onError` and **never logged**. React auto-logs caught errors in development but **not** in production builds, so a caught error in a production app produced **zero console output** (only the visual fallback rendered) — making swallowed exceptions impossible to debug. Now always `console.error(error, info.componentStack)`; the visible fallback is unchanged. Adds a jest test.

---

All three: prod build (`tsconfig.prod.json`) + `jest` pass; new files lint clean.
