### PR TITLE
Add sticky panel header styling props

### DIFF
--- a/__tests__/panel.test.tsx
+++ b/__tests__/panel.test.tsx
@@ -37,6 +37,36 @@ test('Renders basic <Panel /> with title properly', () => {
   expect(document.querySelectorAll('.reqore-panel-content').length).toBe(1);
 });
 
+test('Renders sticky minimal <Panel /> title with explicit sticky header paint', () => {
+  render(
+    <div style={{ width: '1000px' }}>
+      <ReqoreUIProvider>
+        <ReqoreLayoutContent>
+          <ReqorePanel
+            label='Sticky'
+            minimal
+            stickyHeader
+            stickyHeaderOpacity={1}
+            stickyHeaderStyle={{
+              boxShadow: '0 10px 24px rgba(0, 0, 0, 0.28)',
+            }}
+          >
+            Panel
+          </ReqorePanel>
+        </ReqoreLayoutContent>
+      </ReqoreUIProvider>
+    </div>
+  );
+
+  const title = document.querySelector('.reqore-panel-title') as HTMLElement;
+  const style = window.getComputedStyle(title);
+
+  expect(title).toBeTruthy();
+  expect(style.position).toBe('sticky');
+  expect(style.backgroundColor).not.toMatch(/transparent|rgba\(0, 0, 0, 0\)/);
+  expect(title.style.boxShadow).toBe('0 10px 24px rgba(0, 0, 0, 0.28)');
+});
+
 test('Renders basic <Panel /> that is collapsed by default and can be expanded', () => {
   render(
     <div style={{ width: '1000px' }}>

--- a/src/components/Panel/index.tsx
+++ b/src/components/Panel/index.tsx
@@ -198,6 +198,14 @@ export interface IReqorePanelProps
   responsiveActionsWrapperProps?: Partial<IReqoreControlGroupProps>;
   stickyHeader?: boolean;
   stickyHeaderOffset?: number;
+  /**
+   * Override only the sticky title bar background opacity. This is useful for
+   * `minimal` panels, whose title bars are otherwise transparent, when sticky
+   * headers need an opaque surface while content scrolls underneath.
+   */
+  stickyHeaderOpacity?: number;
+  /** Inline styles applied to the title bar only while `stickyHeader` is enabled. */
+  stickyHeaderStyle?: React.CSSProperties;
   floatingActions?: boolean;
   /**
    * Subtle 3D "raised" effect — inset top highlight + inset bottom shadow.
@@ -481,8 +489,11 @@ export const StyledPanelTopBar = styled(StyledPanelTitle)`
   top: ${({ stickyHeader, stickyHeaderOffset = 0 }) =>
     stickyHeader ? `${stickyHeaderOffset}px` : undefined};
   z-index: ${({ stickyHeader }) => (stickyHeader ? 2 : undefined)};
-  background: ${({ theme, opacity = 1 }: IStyledPanel) =>
-    rgba(changeLightness(getMainBackgroundColor(theme), 0.03), opacity)};
+  background: ${({ theme, opacity = 1, stickyHeader, stickyHeaderOpacity }: IStyledPanel) =>
+    rgba(
+      changeLightness(getMainBackgroundColor(theme), 0.03),
+      stickyHeader && stickyHeaderOpacity !== undefined ? stickyHeaderOpacity : opacity
+    )};
 `;
 
 export const StyledPanelBottomActions = styled(StyledPanelTitle)`
@@ -1138,6 +1149,8 @@ export const ReqorePanel = forwardRef<HTMLDivElement, IReqorePanelProps>(
               intent={intent}
               stickyHeader={rest.stickyHeader}
               stickyHeaderOffset={rest.stickyHeaderOffset}
+              stickyHeaderOpacity={rest.stickyHeaderOpacity}
+              style={rest.stickyHeader ? rest.stickyHeaderStyle : undefined}
             >
               {hasTitleHeader && (
                 <StyledPanelTitleHeader>

--- a/src/stories/Panel/Panel.stories.tsx
+++ b/src/stories/Panel/Panel.stories.tsx
@@ -81,6 +81,12 @@ const meta = {
       name: 'Opacity',
       description: 'The opacity of the panel',
     }),
+    ...createArg('stickyHeaderOpacity', {
+      type: 'number',
+      defaultValue: undefined,
+      name: 'Sticky Header Opacity',
+      description: 'The opacity of the sticky header title bar',
+    }),
     ...createArg('labelSize', {
       type: 'string',
       defaultValue: undefined,
@@ -956,6 +962,54 @@ export const StickyHeaderOutsideScroll: Story = {
     }
 
     container.scrollTop = 960;
+    fireEvent.scroll(container);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  },
+};
+
+export const OpaqueStickyHeader: Story = {
+  parameters: {
+    chromatic: {
+      viewports: [600],
+    },
+  },
+  render: () => (
+    <div
+      style={{
+        maxHeight: '360px',
+        width: '600px',
+        overflow: 'auto',
+      }}
+      data-testid='opaque-sticky-scroll-container'
+    >
+      <ReqorePanel
+        label='Opaque sticky header'
+        description='Minimal panel with an opaque sticky title bar'
+        stickyHeader
+        stickyHeaderOpacity={1}
+        stickyHeaderStyle={{
+          boxShadow:
+            '0 10px 24px rgba(0, 0, 0, 0.28), inset 0 -1px 0 rgba(255, 255, 255, 0.08)',
+        }}
+        icon='PushpinLine'
+        minimal
+        padded
+        fluid
+      >
+        {message}
+      </ReqorePanel>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const container = canvasElement.querySelector(
+      '[data-testid="opaque-sticky-scroll-container"]'
+    );
+
+    if (!container) {
+      return;
+    }
+
+    container.scrollTop = 240;
     fireEvent.scroll(container);
     await new Promise((resolve) => setTimeout(resolve, 200));
   },


### PR DESCRIPTION
## Summary
- add stickyHeaderOpacity and stickyHeaderStyle props to ReqorePanel
- allow minimal sticky panel headers to render with an opaque title bar without targeting internal classes
- add unit coverage and a Storybook example for opaque sticky headers

## Verification
- yarn test __tests__/panel.test.tsx
- yarn build:test:prod
- yarn build
- yarn lint
- yarn build-storybook
- git push pre-push hook: lint + full unit suite, 53 files / 618 tests passed
- packed local Reqore build and verified qorus-ide dashboard against it