### PR TITLE
feat(shortcuts): add keyboard shortcut management and badge hints

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,9 @@ module.exports = {
     'react/prop-types': 'off',
     'no-extra-boolean-cast': 'off',
     'no-console': ['error', { allow: ['warn', 'error'] }],
+    // Allow the "omit a key" idiom — `const { dropped, ...rest } = obj` — where
+    // the destructured sibling is intentionally discarded.
+    '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
   },
   // Ignore storybook files
   ignorePatterns: ['**/stories/*', '**/mock/*'],

--- a/.tasks/EDITABLE_DATAVIEW.md
+++ b/.tasks/EDITABLE_DATAVIEW.md
@@ -1,0 +1,171 @@
+# Editable DataView — JSON Schema builder mode
+
+## Current state
+
+ReqoreDataView (src/components/DataView/index.tsx) is a read-only, visually-rich tree renderer for structured payloads:
+
+- **Render-only**: Wraps ReqorePanel + renders `data` (object, array, scalar) as a collapsible tree.
+- **Type-aware display**: Chips colour-code values by kind (string / number / boolean / date / null / object / array) using ReqoreTag with intents.
+- **Envelope detection**: Unwraps `{ type: string, value: unknown }` shapes and labels the value with the type (helpers.ts, line 13-127).
+- **Nested nesting**: Records render as a grid table (key | value pairs), arrays as stacked indexed items; depth levels control collapse state.
+- **Interaction**: `onItemClick` fires on a scalar value (no tree mutation). `onSectionToggle` fires when user expands/collapses a section (no data mutation).
+- **Key primitives**: RecordTable (memo, ResizeObserver for responsive stacking), PreservedDetails (scroll-preserving collapsible), renderTree (pure function, depth-aware).
+- **Props surface**: No data-mutation callbacks; size, intent, theme customization via ReqorePanel forwarding; envelope/parseEmbedded for structural hints.
+
+## Target capability
+
+Turn DataView into an editable JSON Schema builder:
+
+- **Editable inline values**: Property type, description, default value, enum members editable as inline controls (ReqoreInput, ReqoreSelect, ReqoreTa textarea).
+- **Structural edits**: Add/remove properties from objects; add/remove items from arrays; rename keys; reorder (optional).
+- **Schema-aware**: Render JSON Schema constructs (type, properties, required, items, enum, format, minLength, pattern, examples) as visual controls instead of raw JSON.
+- **Nested objects + arrays**: Support building complex schemas (`properties: { name: { type: "string" }, address: { type: "object", properties: {...} } }`).
+- **Validation**: Show errors inline (e.g. "required property 'name' not set"), prevent invalid states (e.g. can't set type="object" without properties).
+- **Callbacks**: `onSchemaChange(newSchema)` after any edit; `onAddProperty(path)`, `onRemoveProperty(path)`, `onChangePropertyType(path, type)`, etc. to wire parent logic.
+
+## Gaps
+
+### 1. Render-as-input gap (index.tsx renderScalar, line 520)
+Currently `renderScalar` returns a static ReqoreTag chip. For editable mode:
+- No dispatch to per-type input component (e.g. ReqoreInput for string values, ReqoreSelect for enum).
+- renderValue does not know about edit intent — renders display-only.
+- **Gap**: Need a "value renderer" pattern similar to ReqoreTree (line 60 `KeyRenderer` / `ValueRenderer` props) or an `editable` flag + callbacks to swap scalar rendering.
+
+### 2. Row add/remove missing (RecordTable, index.tsx line 606)
+RecordTable only renders existing entries; no "add property" or "remove property" UI.
+- **Gap**: Need action buttons (+, ✕) on each row to insert/delete; need an "add row" button after the last entry.
+- Likely a new sub-component or `RecordTable` enhancement to render trailing buttons per row.
+
+### 3. Type picker not built (helpers.ts)
+JSON Schema `type` can be `"string" | "number" | "boolean" | "integer" | "object" | "array" | "null"` — no generic "type picker" exists in Reqore.
+- **Gap**: Need a ReqoreSelect (or custom multi-select for `type: ["string", "null"]`) that renders the JSON Schema type list.
+- No schema-to-option mapping (e.g. type="object" → show +Add Property button, type="array" → show items schema editor).
+
+### 4. Enum editor missing
+JSON Schema `enum: [...]` requires rendering an array of allowed values as editable tags/chips.
+- **Gap**: ReqoreMultiSelect exists (src/components/MultiSelect, line 85) but is not integrated; need wrapper to bind it to the `enum` field.
+
+### 5. Nested object/array editing
+When `type: "object"`, the `properties` field itself is a map of nested schemas. Same for `items` in arrays.
+- **Gap**: Recursive schema rendering — each nested schema is another DataView-like tree that must also be editable.
+- renderTree (index.tsx line 685) handles nesting visually but doesn't know about JSON Schema semantics (when to render a type picker vs. a string input).
+
+### 6. No "required" field editor
+JSON Schema `required: ["name", "age"]` marks which object properties are mandatory.
+- **Gap**: No UI to toggle membership in the required array; no visual indicator (checkbox, badge) next to a property name to mark it required.
+
+### 7. Edit state + callbacks not wired
+Editable mode needs:
+- Edit state per row (isEditing?, focus management).
+- Callback handlers: `onChangeValue(path, value)`, `onChangeType(path, type)`, `onAddProperty(path)`, `onRemoveProperty(path)`.
+- **Gap**: No callbacks defined in IReqoreDataViewProps (index.tsx line 74); ReqorePanel wrapping doesn't expose them.
+
+### 8. Validation + error display
+Schema builder must validate on change (e.g. can't set type="object" without properties; can't have duplicate required entries).
+- **Gap**: No error state model; no inline error rendering (e.g. red intent badge, tooltip, or callout).
+
+### 9. Key rename affordance
+Users must be able to change property names (keys).
+- **Gap**: Key is rendered as a static ReqoreTag (index.tsx line 657); no edit mode swaps it to a ReqoreInput.
+
+### 10. Scroll preservation during edit
+When a row switches from display → edit (inline input appears), ResizeObserver may fire, scroll position shifts.
+- **Gap**: Need to preserve scroll + focus position during mode switch (similar to PreservedDetails, line 429).
+
+## Proposed shape (high-level)
+
+```typescript
+export interface IReqoreDataViewProps {
+  // ... existing props ...
+
+  // Enable editable mode
+  editable?: boolean;
+
+  // Callbacks for edit operations
+  onDataChange?: (data: unknown) => void;  // Called after any edit
+  onAddProperty?: (path: string[]) => void;
+  onRemoveProperty?: (path: string[]) => void;
+  onChangePropertyType?: (path: string[], type: string) => void;
+  onChangePropertyValue?: (path: string[], value: unknown) => void;
+  onRenameProperty?: (path: string[], oldKey: string, newKey: string) => void;
+  onChangeRequired?: (path: string[], required: string[]) => void;
+
+  // Schema mode hint — tells DataView this is a JSON Schema, enable type picker + required indicator
+  schemaMode?: boolean;  // or 'json-schema' | 'openapi' for hints
+
+  // Validation errors
+  errors?: Record<string, string>;  // path.join('.') → error message
+
+  // Custom renderers for special fields
+  PropertyTypeRenderer?: React.ComponentType<{
+    value: unknown;
+    path: string[];
+    onChangeType?: (type: string) => void;
+  }>;
+  EnumValueRenderer?: React.ComponentType<{
+    value: string[];
+    path: string[];
+    onChangeValues?: (values: string[]) => void;
+  }>;
+}
+```
+
+## Implementation phases
+
+### Phase 1: Edit-mode toggle + inline scalar input
+- Add `editable?: boolean` prop to IReqoreDataViewProps.
+- Create a new `EditableScalarCell` component that dispatches to ReqoreInput (text), ReqoreSelect (boolean), etc. based on value type.
+- Modify renderScalar to accept an `onValueChange` callback and swap to EditableScalarCell when editable=true.
+- Test: edit a string scalar, confirm onChange fires and value updates.
+
+### Phase 2: Row add/remove buttons
+- Enhance RecordTable to render action buttons (+, ✕) on each row.
+- Add `onAddProperty(path)` and `onRemoveProperty(path, key)` callbacks.
+- For arrays, add "add item" button after the last item.
+- Test: add a property, remove a property, confirm callbacks fire.
+
+### Phase 3: Key renaming
+- Swap the static key ReqoreTag to an inline-edit component (pattern: Panel.LabelEditor).
+- Add `onRenameProperty(path, oldKey, newKey)` callback.
+- Test: rename a key, confirm validation (duplicate keys not allowed).
+
+### Phase 4: Type picker + schema-aware rendering
+- Build a "JSON Schema type picker" ReqoreSelect (type: "string" | "number" | "object" | "array" | ...).
+- Add `schemaMode?: boolean` prop; when true, detect JSON Schema constructs (type, properties, required, items, enum).
+- Render `type` field as a dropdown; when type changes, conditionally show/hide related fields (e.g. hide "properties" if type != "object").
+- Test: toggle type from "string" to "object", confirm "properties" field appears/disappears.
+
+### Phase 5: Required field editor + enum editor
+- Add checkbox / toggle indicator next to property names when schemaMode=true and parent type="object".
+- Clicking toggles the property's membership in the `required: [...]` array.
+- For `enum: [...]`, integrate ReqoreMultiSelect to add/remove allowed values.
+- Test: mark a property required, toggle it off; add/remove enum values.
+
+### Phase 6: Nested schema editing + validation
+- Recursively render nested `properties` and `items` schemas as editable DataViews.
+- Add error state: display inline badges/callouts for validation failures (e.g. "type='object' requires properties").
+- Test: build a nested schema (object with nested object property), edit at all levels, confirm validation.
+
+### Phase 7: Polish + accessibility
+- Scroll preservation on mode switches (inline input appears).
+- Keyboard navigation (Tab through edits, Escape to cancel, Enter to confirm).
+- Undo/redo (optional; may defer to parent).
+
+## Open questions
+
+1. **Reordering**: Do properties need to reorder? JSON objects are unordered, but UI UX often benefits from drag-to-reorder. Should array items support reordering?
+
+2. **Schema subset**: Must the editor support `oneOf` / `anyOf` / `allOf` (polymorphic schemas)? Or only the core subset (type, properties, required, items, enum, format)?
+
+3. **Validation gate**: Should edits be rejected immediately if invalid (e.g. can't save until all required properties set), or show warnings but allow saves?
+
+4. **Colocated vs. modal**: Is this an inline-editable tree inside a panel, or does editing large schemas open a modal?
+
+5. **Root-level type change**: When schemaMode=true and data is an object, can the user change the root type from "object" to "array" or "string"? (Likely yes; affects row layout.)
+
+6. **Default value editor**: Should the editor support editing `default: ...` field for each property? This needs context-aware input (type matching).
+
+7. **Examples field**: Does the builder need to support the `examples: [...]` field from JSON Schema? (Lower priority; can defer.)
+
+8. **Integration point**: Does this live as props on ReqoreDataView, or as a new ReqoreSchemaBuilder component that wraps DataView + adds edit logic?
+

--- a/__tests__/dataView.test.tsx
+++ b/__tests__/dataView.test.tsx
@@ -1,12 +1,18 @@
 import { fireEvent, render } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
 import {
   ReqoreContent,
   ReqoreDataView,
   ReqoreLayoutContent,
   ReqoreUIProvider,
+  reqoreCoerceValueToKind,
+  reqoreDeleteAtPath,
   reqoreFormatScalar,
   reqoreHasStructuredValue,
   reqoreIsEnvelope,
+  reqoreRenameKeyAtPath,
+  reqoreSetAtPath,
   reqoreUnwrapEnvelope,
 } from '../src';
 
@@ -413,5 +419,555 @@ describe('reqoreHasStructuredValue', () => {
   it('unwraps envelopes before checking', () => {
     expect(reqoreHasStructuredValue({ type: 'list', value: [] })).toBe(false);
     expect(reqoreHasStructuredValue({ type: 'list', value: [1] })).toBe(true);
+  });
+});
+
+describe('reqoreSetAtPath', () => {
+  it('replaces the entire tree when the path is empty', () => {
+    expect(reqoreSetAtPath({ a: 1 }, [], 'x')).toBe('x');
+  });
+
+  it('sets a top-level record key', () => {
+    const before = { a: 1, b: 2 };
+    const after = reqoreSetAtPath(before, ['a'], 99);
+    expect(after).toEqual({ a: 99, b: 2 });
+    expect(after).not.toBe(before);
+  });
+
+  it('sets a nested record key', () => {
+    const before = { outer: { inner: { leaf: 'v1' } }, other: true };
+    const after = reqoreSetAtPath(before, ['outer', 'inner', 'leaf'], 'v2') as Record<
+      string,
+      any
+    >;
+    expect(after.outer.inner.leaf).toBe('v2');
+    expect(after.other).toBe(true);
+    expect(after.outer).not.toBe(before.outer);
+    expect(after.outer.inner).not.toBe(before.outer.inner);
+  });
+
+  it('sets an array index by string path', () => {
+    const before = { tags: ['a', 'b', 'c'] };
+    const after = reqoreSetAtPath(before, ['tags', '1'], 'B') as Record<string, any>;
+    expect(after.tags).toEqual(['a', 'B', 'c']);
+    expect(after.tags).not.toBe(before.tags);
+  });
+
+  it('extends an array when the index is past the end', () => {
+    const before: unknown[] = ['a'];
+    const after = reqoreSetAtPath(before, ['3'], 'd') as unknown[];
+    expect(after).toEqual(['a', undefined, undefined, 'd']);
+  });
+
+  it('creates intermediate containers when walking through a scalar', () => {
+    const before = { user: 'unset' };
+    const after = reqoreSetAtPath(before, ['user', 'name'], 'Ada') as Record<
+      string,
+      any
+    >;
+    expect(after.user).toEqual({ name: 'Ada' });
+  });
+
+  it('creates an intermediate array when the next segment is numeric', () => {
+    const before = { tags: 'unset' };
+    const after = reqoreSetAtPath(before, ['tags', '0'], 'first') as Record<
+      string,
+      any
+    >;
+    expect(after.tags).toEqual(['first']);
+  });
+});
+
+describe('reqoreDeleteAtPath', () => {
+  it('drops a top-level record key', () => {
+    const after = reqoreDeleteAtPath({ a: 1, b: 2 }, ['b']) as Record<string, any>;
+    expect(after).toEqual({ a: 1 });
+  });
+
+  it('splices an array index', () => {
+    const after = reqoreDeleteAtPath({ tags: ['a', 'b', 'c'] }, [
+      'tags',
+      '1',
+    ]) as Record<string, any>;
+    expect(after.tags).toEqual(['a', 'c']);
+  });
+
+  it('returns input unchanged when the path is not resolvable', () => {
+    const before = { a: 1 };
+    expect(reqoreDeleteAtPath(before, ['missing'])).toBe(before);
+  });
+
+  it('returns undefined when the path is empty', () => {
+    expect(reqoreDeleteAtPath({ a: 1 }, [])).toBeUndefined();
+  });
+});
+
+describe('reqoreCoerceValueToKind', () => {
+  it('keeps a string unchanged when coerced to string', () => {
+    expect(reqoreCoerceValueToKind('hello', 'string')).toBe('hello');
+  });
+  it('stringifies a number when coerced to string', () => {
+    expect(reqoreCoerceValueToKind(42, 'string')).toBe('42');
+  });
+  it('parses a numeric string to a number', () => {
+    expect(reqoreCoerceValueToKind('17', 'number')).toBe(17);
+  });
+  it('falls back to 0 when the source string is not numeric', () => {
+    expect(reqoreCoerceValueToKind('hello', 'number')).toBe(0);
+  });
+  it('maps true/1/yes string to a true boolean', () => {
+    expect(reqoreCoerceValueToKind('true', 'boolean')).toBe(true);
+    expect(reqoreCoerceValueToKind('1', 'boolean')).toBe(true);
+    expect(reqoreCoerceValueToKind('Yes', 'boolean')).toBe(true);
+  });
+  it('maps non-zero numbers to true', () => {
+    expect(reqoreCoerceValueToKind(5, 'boolean')).toBe(true);
+    expect(reqoreCoerceValueToKind(0, 'boolean')).toBe(false);
+  });
+  it('keeps an existing record when coerced to object', () => {
+    const existing = { a: 1 };
+    expect(reqoreCoerceValueToKind(existing, 'object')).toBe(existing);
+  });
+  it('returns an empty object when scalar coerced to object', () => {
+    expect(reqoreCoerceValueToKind('whatever', 'object')).toEqual({});
+  });
+  it('keeps an existing array when coerced to array', () => {
+    const existing = [1, 2];
+    expect(reqoreCoerceValueToKind(existing, 'array')).toBe(existing);
+  });
+  it('returns an empty array when scalar coerced to array', () => {
+    expect(reqoreCoerceValueToKind('x', 'array')).toEqual([]);
+  });
+  it('always returns null for null kind', () => {
+    expect(reqoreCoerceValueToKind('value', 'null')).toBeNull();
+  });
+});
+
+describe('reqoreRenameKeyAtPath', () => {
+  it('renames a top-level key preserving insertion order', () => {
+    const before = { a: 1, b: 2, c: 3 };
+    const after = reqoreRenameKeyAtPath(before, [], 'b', 'beta') as Record<
+      string,
+      unknown
+    >;
+    expect(Object.keys(after)).toEqual(['a', 'beta', 'c']);
+    expect(after.beta).toBe(2);
+  });
+
+  it('refuses to overwrite an existing key', () => {
+    const before = { a: 1, b: 2 };
+    const after = reqoreRenameKeyAtPath(before, [], 'a', 'b');
+    expect(after).toBe(before);
+  });
+
+  it('renames a nested key under an array path', () => {
+    const before = { items: [{ name: 'first' }, { name: 'second' }] };
+    const after = reqoreRenameKeyAtPath(before, ['items', '1'], 'name', 'label') as Record<
+      string,
+      any
+    >;
+    expect(after.items[0]).toEqual({ name: 'first' });
+    expect(after.items[1]).toEqual({ label: 'second' });
+  });
+
+  it('returns input unchanged when oldKey is missing', () => {
+    const before = { a: 1 };
+    expect(reqoreRenameKeyAtPath(before, [], 'missing', 'x')).toBe(before);
+  });
+});
+
+describe('editable DataView', () => {
+  const editableTree = {
+    display_name: 'Customer',
+    retries: 3,
+    is_public: false,
+  };
+
+  const Harness = ({
+    onCommit,
+    initial,
+  }: {
+    onCommit?: (next: unknown) => void;
+    initial?: unknown;
+  }) => {
+    const [tree, setTree] = useState<unknown>(initial ?? editableTree);
+    return (
+      <ReqoreDataView
+        data={tree}
+        editable
+        collapsibleRoot={false}
+        onDataChange={(next) => {
+          setTree(next);
+          onCommit?.(next);
+        }}
+      />
+    );
+  };
+
+  const findRow = (container: HTMLElement, keyName: string) => {
+    const rows = Array.from(
+      container.querySelectorAll('.reqore-data-view-row')
+    );
+    return rows.find(
+      (r) => r.querySelector('.reqore-data-view-key')?.textContent === keyName
+    ) as HTMLElement | undefined;
+  };
+
+  it('renders chips by default (no inputs until clicked)', () => {
+    const { container } = render(wrap(<Harness />));
+    // display_name + retries are scalars but render as chips, not
+    // inputs, until clicked.
+    expect(
+      container.querySelectorAll('input.reqore-data-view-edit').length
+    ).toBe(0);
+    expect(
+      container.querySelectorAll('.reqore-data-view-value').length
+    ).toBeGreaterThan(0);
+  });
+
+  it('swaps chip → input on click and commits the edit on Enter', () => {
+    const onCommit = vi.fn();
+    const { container } = render(wrap(<Harness onCommit={onCommit} />));
+    const row = findRow(container, 'display_name')!;
+    const chip = row.querySelector('.reqore-data-view-value') as HTMLElement;
+    fireEvent.click(chip);
+    const input = row.querySelector(
+      'input.reqore-data-view-edit'
+    ) as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.value).toBe('Customer');
+    fireEvent.change(input, { target: { value: 'Customer 2' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    const last = onCommit.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(last.display_name).toBe('Customer 2');
+  });
+
+  it('commits via the visible Save button', () => {
+    const onCommit = vi.fn();
+    const { container } = render(wrap(<Harness onCommit={onCommit} />));
+    const row = findRow(container, 'display_name')!;
+    fireEvent.click(row.querySelector('.reqore-data-view-value') as HTMLElement);
+    const input = row.querySelector(
+      'input.reqore-data-view-edit'
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Customer v2' } });
+    const commitBtn = row.querySelector(
+      '.reqore-data-view-edit-commit'
+    ) as HTMLElement;
+    expect(commitBtn).toBeTruthy();
+    // mousedown is the actual commit trigger so the input doesn't
+    // blur-commit before the button click resolves.
+    fireEvent.mouseDown(commitBtn);
+    const last = onCommit.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(last.display_name).toBe('Customer v2');
+  });
+
+  it('reverts via the visible Cancel button without firing onCommit', () => {
+    const onCommit = vi.fn();
+    const { container } = render(wrap(<Harness onCommit={onCommit} />));
+    const row = findRow(container, 'display_name')!;
+    fireEvent.click(row.querySelector('.reqore-data-view-value') as HTMLElement);
+    const input = row.querySelector(
+      'input.reqore-data-view-edit'
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'discarded' } });
+    const cancelBtn = row.querySelector(
+      '.reqore-data-view-edit-cancel'
+    ) as HTMLElement;
+    expect(cancelBtn).toBeTruthy();
+    fireEvent.mouseDown(cancelBtn);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('reverts on Escape without firing onCommit', () => {
+    const onCommit = vi.fn();
+    const { container } = render(wrap(<Harness onCommit={onCommit} />));
+    const row = findRow(container, 'display_name')!;
+    fireEvent.click(row.querySelector('.reqore-data-view-value') as HTMLElement);
+    const input = row.querySelector(
+      'input.reqore-data-view-edit'
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'discarded' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('commits a numeric edit as a Number, not a string', () => {
+    const onCommit = vi.fn();
+    const { container } = render(wrap(<Harness onCommit={onCommit} />));
+    const row = findRow(container, 'retries')!;
+    fireEvent.click(row.querySelector('.reqore-data-view-value') as HTMLElement);
+    const input = row.querySelector(
+      'input.reqore-data-view-edit'
+    ) as HTMLInputElement;
+    expect(input.type).toBe('number');
+    fireEvent.change(input, { target: { value: '7' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    const last = onCommit.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(last.retries).toBe(7);
+  });
+
+  it('renders a boolean as a chip in display mode (no inline checkbox)', () => {
+    const { container } = render(wrap(<Harness />));
+    const row = findRow(container, 'is_public')!;
+    // Display mode is consistent with other scalars — the chip
+    // shows the value; the editable affordances live in edit mode.
+    expect(row.querySelector('.reqore-data-view-value')).toBeTruthy();
+    expect(row.querySelector('input[type="checkbox"]')).toBeNull();
+  });
+
+  it('edits a boolean via chip → checkbox toggle → save', () => {
+    const onCommit = vi.fn();
+    const { container } = render(wrap(<Harness onCommit={onCommit} />));
+    const row = findRow(container, 'is_public')!;
+    // Step 1: click the chip → enter edit mode → checkbox appears.
+    fireEvent.click(row.querySelector('.reqore-data-view-value') as HTMLElement);
+    const checkbox = row.querySelector(
+      '.reqore-data-view-edit-bool'
+    ) as HTMLElement;
+    expect(checkbox).toBeTruthy();
+    // Step 2: click checkbox → toggles the LOCAL draft, no commit yet.
+    fireEvent.click(checkbox);
+    expect(onCommit).not.toHaveBeenCalled();
+    // Step 3: click Save → commits the toggled draft (true).
+    fireEvent.mouseDown(
+      row.querySelector('.reqore-data-view-edit-commit') as HTMLElement
+    );
+    const last = onCommit.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(last.is_public).toBe(true);
+  });
+
+  it('discards a boolean toggle when Cancel is clicked', () => {
+    const onCommit = vi.fn();
+    const { container } = render(wrap(<Harness onCommit={onCommit} />));
+    const row = findRow(container, 'is_public')!;
+    fireEvent.click(row.querySelector('.reqore-data-view-value') as HTMLElement);
+    fireEvent.click(
+      row.querySelector('.reqore-data-view-edit-bool') as HTMLElement
+    );
+    fireEvent.mouseDown(
+      row.querySelector('.reqore-data-view-edit-cancel') as HTMLElement
+    );
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('shows the type picker when editing a boolean', () => {
+    const { container } = render(wrap(<Harness />));
+    const row = findRow(container, 'is_public')!;
+    fireEvent.click(row.querySelector('.reqore-data-view-value') as HTMLElement);
+    // The same picker that scalar cells use is reachable on booleans,
+    // since both kinds share the edit-mode control group.
+    expect(row.querySelector('.reqore-data-view-edit-type')).toBeTruthy();
+  });
+
+  it('renames a key via the inline key cell', () => {
+    const onCommit = vi.fn();
+    const { container } = render(wrap(<Harness onCommit={onCommit} />));
+    const row = findRow(container, 'display_name')!;
+    const keyChip = row.querySelector('.reqore-data-view-key') as HTMLElement;
+    fireEvent.click(keyChip);
+    const keyInput = row.querySelector(
+      'input.reqore-data-view-key-edit'
+    ) as HTMLInputElement;
+    expect(keyInput).toBeTruthy();
+    fireEvent.change(keyInput, { target: { value: 'label' } });
+    fireEvent.keyDown(keyInput, { key: 'Enter' });
+    const last = onCommit.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(Object.keys(last)).toEqual(['label', 'retries', 'is_public']);
+    expect(last.label).toBe('Customer');
+  });
+
+  it('refuses a duplicate key rename', () => {
+    const onCommit = vi.fn();
+    const { container } = render(wrap(<Harness onCommit={onCommit} />));
+    const row = findRow(container, 'display_name')!;
+    fireEvent.click(row.querySelector('.reqore-data-view-key') as HTMLElement);
+    const keyInput = row.querySelector(
+      'input.reqore-data-view-key-edit'
+    ) as HTMLInputElement;
+    fireEvent.change(keyInput, { target: { value: 'retries' } });
+    fireEvent.keyDown(keyInput, { key: 'Enter' });
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('removes a row when the delete action fires', () => {
+    const onCommit = vi.fn();
+    const { container } = render(wrap(<Harness onCommit={onCommit} />));
+    const row = findRow(container, 'retries')!;
+    const deleteBtn = row.querySelector(
+      '.reqore-data-view-row-delete'
+    ) as HTMLElement;
+    expect(deleteBtn).toBeTruthy();
+    fireEvent.click(deleteBtn);
+    const last = onCommit.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect('retries' in last).toBe(false);
+    expect(last.display_name).toBe('Customer');
+  });
+
+  it('adds a new string property via the Add property affordance', () => {
+    const onCommit = vi.fn();
+    const { container } = render(
+      wrap(<Harness onCommit={onCommit} initial={{}} />)
+    );
+    const addRow = container.querySelector(
+      '.reqore-data-view-add-row'
+    ) as HTMLElement;
+    expect(addRow.getAttribute('data-state')).toBe('collapsed');
+    fireEvent.click(addRow.querySelector('button') as HTMLElement);
+    expect(
+      (
+        container.querySelector('.reqore-data-view-add-row') as HTMLElement
+      ).getAttribute('data-state')
+    ).toBe('expanded');
+    const keyInput = container.querySelector(
+      'input.reqore-data-view-add-key'
+    ) as HTMLInputElement;
+    fireEvent.change(keyInput, { target: { value: 'name' } });
+    const commit = container.querySelector(
+      '.reqore-data-view-add-commit'
+    ) as HTMLElement;
+    fireEvent.click(commit);
+    const last = onCommit.mock.calls.at(-1)?.[0];
+    expect(last).toEqual({ name: '' });
+  });
+
+  it('refuses an empty key from the Add property affordance', () => {
+    const onCommit = vi.fn();
+    const { container } = render(
+      wrap(<Harness onCommit={onCommit} initial={{}} />)
+    );
+    const addRow = container.querySelector(
+      '.reqore-data-view-add-row'
+    ) as HTMLElement;
+    fireEvent.click(addRow.querySelector('button') as HTMLElement);
+    const commit = container.querySelector(
+      '.reqore-data-view-add-commit'
+    ) as HTMLElement;
+    fireEvent.click(commit);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('appends an item to an array via the Add item affordance', () => {
+    const onCommit = vi.fn();
+    const { container } = render(
+      wrap(<Harness onCommit={onCommit} initial={{ tags: ['a', 'b'] }} />)
+    );
+    // Find the array's Add affordance — it lives under the array
+    // stack, not the record's top-level affordance.
+    const arrayStack = container.querySelector(
+      '.reqore-data-view-array'
+    ) as HTMLElement;
+    const addRow = arrayStack.querySelector(
+      '.reqore-data-view-add-row'
+    ) as HTMLElement;
+    expect(addRow).toBeTruthy();
+    fireEvent.click(addRow.querySelector('button') as HTMLElement);
+    // No key input for arrays — only the type picker + commit.
+    expect(
+      addRow.querySelector('input.reqore-data-view-add-key')
+    ).toBeNull();
+    fireEvent.click(
+      addRow.querySelector('.reqore-data-view-add-commit') as HTMLElement
+    );
+    const last = onCommit.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(last.tags).toEqual(['a', 'b', '']);
+  });
+
+  it('exposes no type picker outside edit mode', () => {
+    const { container } = render(
+      wrap(<Harness initial={{ count: '7' }} />)
+    );
+    // No row-level type picker — type-changing is a per-edit
+    // concern, not a permanent row action.
+    expect(
+      container.querySelectorAll('.reqore-data-view-row-type-picker').length
+    ).toBe(0);
+  });
+
+  it('shows the type picker only while editing the value', () => {
+    const { container } = render(
+      wrap(<Harness initial={{ count: '7' }} />)
+    );
+    const row = findRow(container, 'count')!;
+    // Before entering edit mode there's no type picker.
+    expect(row.querySelector('.reqore-data-view-edit-type')).toBeNull();
+    // Click the chip → edit mode → picker is in the control group.
+    fireEvent.click(row.querySelector('.reqore-data-view-value') as HTMLElement);
+    expect(row.querySelector('.reqore-data-view-edit-type')).toBeTruthy();
+  });
+
+  it('coerces a numeric-string draft to a Number when type-picking', () => {
+    const onCommit = vi.fn();
+    const { container } = render(
+      wrap(<Harness onCommit={onCommit} initial={{ count: '42' }} />)
+    );
+    const row = findRow(container, 'count')!;
+    fireEvent.click(row.querySelector('.reqore-data-view-value') as HTMLElement);
+    fireEvent.click(
+      row.querySelector('.reqore-data-view-edit-type') as HTMLElement
+    );
+    const numberItem = Array.from(
+      document.querySelectorAll('.reqore-menu-item')
+    ).find((item) => item.textContent?.includes('Number')) as HTMLElement;
+    expect(numberItem).toBeTruthy();
+    fireEvent.click(numberItem);
+    const last = onCommit.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(last.count).toBe(42);
+  });
+
+  it('falls back to 0 when type-picking Number from a non-numeric string', () => {
+    const onCommit = vi.fn();
+    const { container } = render(
+      wrap(<Harness onCommit={onCommit} initial={{ count: 'seven' }} />)
+    );
+    const row = findRow(container, 'count')!;
+    fireEvent.click(row.querySelector('.reqore-data-view-value') as HTMLElement);
+    fireEvent.click(
+      row.querySelector('.reqore-data-view-edit-type') as HTMLElement
+    );
+    const numberItem = Array.from(
+      document.querySelectorAll('.reqore-menu-item')
+    ).find((item) => item.textContent?.includes('Number')) as HTMLElement;
+    fireEvent.click(numberItem);
+    const last = onCommit.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(last.count).toBe(0);
+  });
+
+  it('converts a scalar to an empty object via the edit-mode type picker', () => {
+    const onCommit = vi.fn();
+    const { container } = render(
+      wrap(<Harness onCommit={onCommit} initial={{ payload: 'x' }} />)
+    );
+    const row = findRow(container, 'payload')!;
+    fireEvent.click(row.querySelector('.reqore-data-view-value') as HTMLElement);
+    fireEvent.click(
+      row.querySelector('.reqore-data-view-edit-type') as HTMLElement
+    );
+    const objectItem = Array.from(
+      document.querySelectorAll('.reqore-menu-item')
+    ).find((item) => item.textContent?.includes('Object')) as HTMLElement;
+    fireEvent.click(objectItem);
+    const last = onCommit.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(last.payload).toEqual({});
+  });
+
+  it('deletes an array item via the per-row action group', () => {
+    const onCommit = vi.fn();
+    const { container } = render(
+      wrap(
+        <Harness onCommit={onCommit} initial={{ tags: ['a', 'b', 'c'] }} />
+      )
+    );
+    const arrayItems = container.querySelectorAll(
+      '.reqore-data-view-array-item'
+    );
+    expect(arrayItems.length).toBe(3);
+    const second = arrayItems[1] as HTMLElement;
+    const deleteBtn = second.querySelector(
+      '.reqore-data-view-row-delete'
+    ) as HTMLElement;
+    fireEvent.click(deleteBtn);
+    const last = onCommit.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(last.tags).toEqual(['a', 'c']);
   });
 });

--- a/__tests__/keyboardShortcut.test.tsx
+++ b/__tests__/keyboardShortcut.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent, render } from '@testing-library/react';
+import {
+  formatShortcut,
+  formatShortcutCombo,
+  ReqoreButton,
+  ReqoreContent,
+  ReqoreInput,
+  ReqoreKeyboardShortcut,
+  ReqoreLayoutContent,
+  ReqoreUIProvider,
+  shortcutHasModifier,
+} from '../src';
+
+describe('formatShortcut helpers', () => {
+  it('formats a combo with the platform-appropriate glyphs', () => {
+    // non-mac
+    expect(formatShortcutCombo('mod+k', false)).toBe('Ctrl+K');
+    expect(formatShortcutCombo('ctrl+shift+s', false)).toBe('Ctrl+Shift+S');
+    // mac
+    expect(formatShortcutCombo('mod+k', true)).toBe('⌘K');
+    expect(formatShortcutCombo('mod+shift+k', true)).toBe('⌘⇧K');
+  });
+
+  it('handles input focusRules aliases', () => {
+    expect(formatShortcutCombo('letters', false)).toBe('A-Z');
+    expect(formatShortcutCombo('numbers', false)).toBe('0-9');
+  });
+
+  it('splits arrays and comma-separated alternatives', () => {
+    expect(formatShortcut(['mod+k', 'ctrl+j'], false)).toEqual(['Ctrl+K', 'Ctrl+J']);
+    expect(formatShortcut('mod+k, ctrl+j', false)).toEqual(['Ctrl+K', 'Ctrl+J']);
+  });
+
+  it('detects modifiers', () => {
+    expect(shortcutHasModifier('mod+k')).toBe(true);
+    expect(shortcutHasModifier('shift+a')).toBe(true);
+    expect(shortcutHasModifier('k')).toBe(false);
+    expect(shortcutHasModifier(['j', 'mod+k'])).toBe(true);
+  });
+});
+
+describe('ReqoreKeyboardShortcut component', () => {
+  it('renders one badge per alternative combo', () => {
+    render(
+      <ReqoreUIProvider>
+        <ReqoreLayoutContent>
+          <ReqoreContent>
+            <ReqoreKeyboardShortcut shortcut={['mod+k', 'ctrl+j']} />
+          </ReqoreContent>
+        </ReqoreLayoutContent>
+      </ReqoreUIProvider>
+    );
+
+    expect(document.querySelectorAll('.reqore-keyboard-shortcut-key').length).toBe(2);
+  });
+});
+
+describe('ReqoreButton shortcut', () => {
+  it('renders a shortcut hint badge', () => {
+    render(
+      <ReqoreUIProvider>
+        <ReqoreLayoutContent>
+          <ReqoreContent>
+            <ReqoreButton shortcut='mod+k'>Search</ReqoreButton>
+          </ReqoreContent>
+        </ReqoreLayoutContent>
+      </ReqoreUIProvider>
+    );
+
+    expect(document.querySelector('.reqore-keyboard-shortcut')).toBeTruthy();
+  });
+
+  it('hides the hint when shortcutHint is false', () => {
+    render(
+      <ReqoreUIProvider>
+        <ReqoreLayoutContent>
+          <ReqoreContent>
+            <ReqoreButton shortcut='mod+k' shortcutHint={false}>
+              Search
+            </ReqoreButton>
+          </ReqoreContent>
+        </ReqoreLayoutContent>
+      </ReqoreUIProvider>
+    );
+
+    expect(document.querySelector('.reqore-keyboard-shortcut')).toBeFalsy();
+  });
+
+  it('hides the hint when shortcutHints is globally disabled', () => {
+    render(
+      <ReqoreUIProvider options={{ shortcutHints: false }}>
+        <ReqoreLayoutContent>
+          <ReqoreContent>
+            <ReqoreButton shortcut='mod+k'>Search</ReqoreButton>
+          </ReqoreContent>
+        </ReqoreLayoutContent>
+      </ReqoreUIProvider>
+    );
+
+    expect(document.querySelector('.reqore-keyboard-shortcut')).toBeFalsy();
+  });
+
+  it('triggers onClick when the shortcut is pressed', () => {
+    const onClick = vi.fn();
+
+    render(
+      <ReqoreUIProvider>
+        <ReqoreLayoutContent>
+          <ReqoreContent>
+            <ReqoreButton shortcut='mod+k' onClick={onClick}>
+              Search
+            </ReqoreButton>
+          </ReqoreContent>
+        </ReqoreLayoutContent>
+      </ReqoreUIProvider>
+    );
+
+    // Press both modifiers so the test matches regardless of platform — when
+    // `mod` is used react-hotkeys-hook only checks the platform-appropriate one
+    fireEvent.keyDown(document, { key: 'k', code: 'KeyK', ctrlKey: true, metaKey: true });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trigger onClick when disabled', () => {
+    const onClick = vi.fn();
+
+    render(
+      <ReqoreUIProvider>
+        <ReqoreLayoutContent>
+          <ReqoreContent>
+            <ReqoreButton shortcut='mod+k' onClick={onClick} disabled>
+              Search
+            </ReqoreButton>
+          </ReqoreContent>
+        </ReqoreLayoutContent>
+      </ReqoreUIProvider>
+    );
+
+    fireEvent.keyDown(document, { key: 'k', code: 'KeyK', ctrlKey: true, metaKey: true });
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});
+
+describe('ReqoreInput shortcut hint', () => {
+  it('renders a hint from focusRules shortcut', () => {
+    render(
+      <ReqoreUIProvider>
+        <ReqoreLayoutContent>
+          <ReqoreContent>
+            <ReqoreInput focusRules={{ type: 'keypress', shortcut: '/' }} />
+          </ReqoreContent>
+        </ReqoreLayoutContent>
+      </ReqoreUIProvider>
+    );
+
+    expect(document.querySelector('.reqore-keyboard-shortcut')).toBeTruthy();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.69.6",
+  "version": "0.70.0",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.69.5",
+  "version": "0.69.6",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -102,6 +102,7 @@
     "polished": "^4.2.2",
     "re-resizable": "^6.9.0",
     "react-aria-components": "^1.2.0",
+    "react-hotkeys-hook": "^5.3.2",
     "react-icons": "5.4.0",
     "react-popper": "^2.3.0",
     "react-scrollbar": "^0.5.6",

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,6 +1,7 @@
 import { size } from 'lodash';
 import { rgba, saturate, tint } from 'polished';
 import React, { forwardRef, memo, useCallback, useMemo } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
 import styled, { css } from 'styled-components';
 import { CONTROL_ICON_OPACITY } from '../../constants/colors';
 import {
@@ -23,7 +24,9 @@ import {
   getReadableColorFrom,
   isAchromatic,
 } from '../../helpers/colors';
+import { shortcutHasModifier, TReqoreKeyboardShortcut } from '../../helpers/shortcuts';
 import { alignToFlexAlign, getOneLessSize } from '../../helpers/utils';
+import { useCombinedRefs } from '../../hooks/useCombinedRefs';
 import { useReqoreProperty } from '../../hooks/useReqoreContext';
 import { useReqoreEffect } from '../../hooks/useReqoreEffect';
 import { useReqoreTheme } from '../../hooks/useTheme';
@@ -58,6 +61,7 @@ import {
   TReqoreHexColor,
 } from '../Effect';
 import ReqoreIcon, { IReqoreIconProps } from '../Icon';
+import { ReqoreKeyboardShortcut } from '../KeyboardShortcut';
 import { ReqoreHorizontalSpacer, ReqoreSpacer } from '../Spacer';
 import ReqoreTag, { IReqoreTagProps } from '../Tag';
 import ReqoreTagGroup from '../Tag/group';
@@ -94,6 +98,20 @@ export interface IReqoreButtonProps
   customTheme?: IReqoreCustomTheme;
   wrap?: boolean;
   badge?: TReqoreBadge | TReqoreBadge[];
+
+  /**
+   * Keyboard shortcut that triggers the button's `onClick`, following the
+   * `react-hotkeys-hook` syntax (e.g. `'mod+k'`, `'ctrl+shift+s'`, or an array
+   * of alternatives). The `mod` modifier maps to `⌘` on macOS and `Ctrl`
+   * elsewhere. Combos that include a modifier also fire while a form field is
+   * focused; bare single-key shortcuts do not, to avoid clashing with typing.
+   */
+  shortcut?: TReqoreKeyboardShortcut;
+  /**
+   * Whether to render the badge-style hint for `shortcut`. Defaults to `true`,
+   * unless globally disabled via the `shortcutHints` UI option.
+   */
+  shortcutHint?: boolean;
 
   description?: string | number;
   maxWidth?: string;
@@ -513,14 +531,37 @@ const ReqoreButton = memo(
         as,
         animated,
         loading,
+        shortcut,
+        shortcutHint,
         loadingIconType,
         ...rest
       }: IReqoreButtonProps,
       ref
     ) => {
       const animations = useReqoreProperty('animations');
+      const shortcutHintsEnabled = useReqoreProperty('shortcutHints');
       const theme = useReqoreTheme('main', customTheme, intent);
       const fixedEffect = useReqoreEffect('buttons', theme, effect);
+      const { targetRef } = useCombinedRefs(ref);
+
+      const shortcutEnabled = !!shortcut && !rest.disabled && !readOnly && !loading;
+
+      useHotkeys(
+        shortcut ?? [],
+        (event) => {
+          event.preventDefault();
+          (targetRef.current as HTMLButtonElement)?.click();
+        },
+        {
+          enabled: shortcutEnabled,
+          enableOnFormTags: shortcut ? shortcutHasModifier(shortcut) : false,
+          preventDefault: true,
+        },
+        [shortcut, shortcutEnabled]
+      );
+
+      const showShortcutHint =
+        !!shortcut && shortcutHint !== false && shortcutHintsEnabled !== false;
 
       // If color or intent was specified, set the color
       const customColor = useMemo(
@@ -585,7 +626,7 @@ const ReqoreButton = memo(
             tooltip,
           }}
           Component={StyledButton}
-          ref={ref}
+          ref={targetRef}
         >
           <StyledButtonContent size={size} wrap={wrap} description={description} flat={_flat}>
             {hasLeftIcon ? (
@@ -723,6 +764,12 @@ const ReqoreButton = memo(
                 />
               </>
             )}
+            {showShortcutHint ? (
+              <>
+                <ReqoreSpacer width={PADDING_FROM_SIZE[size] / 2} />
+                <ReqoreKeyboardShortcut shortcut={shortcut} size={size} compact={_compact} />
+              </>
+            ) : null}
           </StyledButtonContent>
 
           {description && (

--- a/src/components/DataView/helpers.ts
+++ b/src/components/DataView/helpers.ts
@@ -139,6 +139,178 @@ export const reqoreHasStructuredValue = (
   return true;
 };
 
+/** Immutable set-at-path — walks the structural tree (`data`),
+ *  produces a new copy with the leaf at `path` replaced by `value`, and
+ *  returns it. Used by the editable mode to apply per-cell edits while
+ *  keeping the surrounding shape intact for diffing / undo / parent
+ *  re-renders.
+ *
+ *  Supports nested records and arrays. Numeric path segments are
+ *  interpreted as array indices when the parent at that level is an
+ *  array. Out-of-range array indices extend the array (pushes
+ *  `undefined` into the gap) — useful when an "add item" affordance
+ *  appends to a list. Setting a record key that does not yet exist
+ *  creates it. */
+export const reqoreSetAtPath = (
+  data: unknown,
+  path: ReadonlyArray<string>,
+  value: unknown
+): unknown => {
+  if (path.length === 0) return value;
+  const [head, ...rest] = path;
+  if (Array.isArray(data)) {
+    const index = Number.parseInt(head, 10);
+    if (Number.isNaN(index) || index < 0) return data;
+    const next = data.slice();
+    while (next.length <= index) next.push(undefined);
+    next[index] = reqoreSetAtPath(next[index], rest, value);
+    return next;
+  }
+  if (reqoreIsRecord(data)) {
+    return { ...data, [head]: reqoreSetAtPath((data as Record<string, unknown>)[head], rest, value) };
+  }
+  // Walking into a scalar — synthesize the missing container based on
+  // the next path segment (numeric → array, otherwise record).
+  const nextIsArray = /^\d+$/.test(head);
+  const container: unknown = nextIsArray ? [] : {};
+  return reqoreSetAtPath(container, path, value);
+};
+
+/** Coerce a value to a target value-kind, preserving the existing
+ *  content where reasonable. Powers the inline type-change picker —
+ *  when the operator flips a string to a number we try to parse it;
+ *  when they flip a number to a boolean we use the standard
+ *  zero-is-false rule; flips to an object or array discard the scalar
+ *  and yield an empty container ready to be filled in.
+ *
+ *  Returns sensible defaults when conversion isn't possible:
+ *    - string  → unchanged for string; `String(value)` for scalars; `''` for objects/arrays/null
+ *    - number  → parsed when possible; `0` otherwise; booleans → 0/1
+ *    - boolean → unchanged for boolean; `'true'`/`'1'` → true; numbers → !!value; else false
+ *    - object  → unchanged for record; `{}` otherwise
+ *    - array   → unchanged for array; `[]` otherwise
+ *    - null    → always `null`
+ */
+export const reqoreCoerceValueToKind = (
+  current: unknown,
+  kind: TReqoreDataValueKind
+): unknown => {
+  switch (kind) {
+    case 'string':
+      if (typeof current === 'string') return current;
+      if (typeof current === 'number' || typeof current === 'boolean') {
+        return String(current);
+      }
+      return '';
+    case 'number': {
+      if (typeof current === 'number') return current;
+      if (typeof current === 'boolean') return current ? 1 : 0;
+      if (typeof current === 'string') {
+        const trimmed = current.trim();
+        if (trimmed === '') return 0;
+        const parsed = Number(trimmed);
+        return Number.isNaN(parsed) ? 0 : parsed;
+      }
+      return 0;
+    }
+    case 'boolean':
+      if (typeof current === 'boolean') return current;
+      if (typeof current === 'number') return current !== 0;
+      if (typeof current === 'string') {
+        const lower = current.trim().toLowerCase();
+        return lower === 'true' || lower === '1' || lower === 'yes';
+      }
+      return false;
+    case 'object':
+      return reqoreIsRecord(current) ? current : {};
+    case 'array':
+      return Array.isArray(current) ? current : [];
+    case 'null':
+    default:
+      return null;
+  }
+};
+
+/** Immutable key-rename — locate the record at `path` and rename one
+ *  of its keys while preserving the insertion order of every other
+ *  key. Returns the input unchanged if the path doesn't resolve to a
+ *  record, if `oldKey` isn't a key on that record, or if `newKey` is
+ *  already taken (refuses to overwrite). */
+export const reqoreRenameKeyAtPath = (
+  data: unknown,
+  path: ReadonlyArray<string>,
+  oldKey: string,
+  newKey: string
+): unknown => {
+  if (oldKey === newKey) return data;
+  if (path.length === 0) {
+    if (!reqoreIsRecord(data)) return data;
+    if (!(oldKey in data) || newKey in data) return data;
+    const next: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(data)) {
+      next[k === oldKey ? newKey : k] = v;
+    }
+    return next;
+  }
+  const [head, ...rest] = path;
+  if (Array.isArray(data)) {
+    const index = Number.parseInt(head, 10);
+    if (Number.isNaN(index) || index < 0 || index >= data.length) return data;
+    const arr = data.slice();
+    arr[index] = reqoreRenameKeyAtPath(arr[index], rest, oldKey, newKey);
+    return arr;
+  }
+  if (reqoreIsRecord(data)) {
+    return {
+      ...data,
+      [head]: reqoreRenameKeyAtPath(
+        (data as Record<string, unknown>)[head],
+        rest,
+        oldKey,
+        newKey
+      ),
+    };
+  }
+  return data;
+};
+
+/** Immutable delete-at-path — walks the structural tree (`data`),
+ *  produces a new copy with the leaf at `path` removed. For records,
+ *  the key is dropped; for arrays, the index is spliced out (so later
+ *  indices shift down). Returns the input unchanged if the path
+ *  doesn't resolve. */
+export const reqoreDeleteAtPath = (
+  data: unknown,
+  path: ReadonlyArray<string>
+): unknown => {
+  if (path.length === 0) return undefined;
+  const [head, ...rest] = path;
+  if (Array.isArray(data)) {
+    const index = Number.parseInt(head, 10);
+    if (Number.isNaN(index) || index < 0 || index >= data.length) return data;
+    if (rest.length === 0) {
+      const next = data.slice();
+      next.splice(index, 1);
+      return next;
+    }
+    const next = data.slice();
+    next[index] = reqoreDeleteAtPath(next[index], rest);
+    return next;
+  }
+  if (reqoreIsRecord(data)) {
+    if (!(head in data)) return data;
+    if (rest.length === 0) {
+      const { [head]: _dropped, ...remaining } = data as Record<string, unknown>;
+      return remaining;
+    }
+    return {
+      ...data,
+      [head]: reqoreDeleteAtPath((data as Record<string, unknown>)[head], rest),
+    };
+  }
+  return data;
+};
+
 /** The shape returned by a custom `parseEmbedded` hook — used by the
  *  view to swap an embedded structured string in-place for the parsed
  *  tree. The optional `prefix` lets the source string carry a leading

--- a/src/components/DataView/index.tsx
+++ b/src/components/DataView/index.tsx
@@ -53,7 +53,11 @@ import { IReqoreTheme, TReqoreIntent } from '../../constants/theme';
 import { TReqoreEffectColor } from '../Effect';
 import { getReadableColor } from '../../helpers/colors';
 import { useReqoreTheme } from '../../hooks/useTheme';
+import ReqoreButton from '../Button';
+import ReqoreCheckbox from '../Checkbox';
 import ReqoreControlGroup from '../ControlGroup';
+import ReqoreDropdown from '../Dropdown';
+import ReqoreInput from '../Input';
 import { ReqoreP } from '../Paragraph';
 import { ReqorePanel, IReqorePanelProps } from '../Panel';
 import ReqoreTag from '../Tag';
@@ -62,12 +66,17 @@ import {
   IReqoreDataViewEmbedded,
   IReqoreDataViewEnvelope,
   IReqoreDataViewScalarOptions,
+  TReqoreDataValueKind,
+  reqoreCoerceValueToKind,
   reqoreDataValueIntent,
   reqoreDataValueKind,
+  reqoreDeleteAtPath,
   reqoreEnvelopeType,
   reqoreFormatScalar,
   reqoreHasStructuredValue,
   reqoreIsRecord,
+  reqoreRenameKeyAtPath,
+  reqoreSetAtPath,
   reqoreUnwrapEnvelope,
 } from './helpers';
 
@@ -134,6 +143,64 @@ export interface IReqoreDataViewProps
    *  intent entirely (useful when paired with `keyColor`). Defaults to
    *  `'info'`. */
   keyIntent?: TReqoreIntent | null;
+
+  /** Enable inline editing. When `true`, the view becomes a
+   *  click-to-edit tree:
+   *    - **Scalars** (string / number / boolean / null) render as
+   *      value chips by default; click → input; blur / Enter → commit;
+   *      Escape → revert.
+   *    - **Keys** render as static tags by default; click → input;
+   *      blur / Enter → rename (refused when the new key already
+   *      exists on the parent record); Escape → revert.
+   *    - **Rows** reveal a delete button on hover.
+   *    - **Records and arrays** show a trailing `+ Add property` /
+   *      `+ Add item` affordance that opens an inline form picking
+   *      key (records only) + initial value type (string, number,
+   *      boolean, null, object, array). Submitting appends the new
+   *      entry.
+   *
+   *  The DataView never owns the tree — every commit fires
+   *  `onDataChange(next)` with the FULL updated structure; the parent
+   *  re-feeds it back via `data` on the next render. Path-level
+   *  callbacks (`onValueChange`, `onAddProperty`, …) fire alongside
+   *  for consumers that want to route a single change through a
+   *  reducer. */
+  editable?: boolean;
+
+  /** Fired with the full updated `data` tree after every commit
+   *  (value edit, key rename, row delete, row add). The DataView is
+   *  fully controlled — the parent is the single source of truth. */
+  onDataChange?: (next: unknown) => void;
+
+  /** Path-level edit callback for scalar value changes. */
+  onValueChange?: (path: string[], value: unknown) => void;
+
+  /** Fired when the operator deletes a row. For a record, `path`
+   *  ends in the key being removed; for an array, in the index. */
+  onRemoveProperty?: (path: string[]) => void;
+
+  /** Fired when the operator renames a record key. `path` is the
+   *  path of the parent record (so `path` + `[oldKey]` is where the
+   *  value lived). */
+  onRenameProperty?: (path: string[], oldKey: string, newKey: string) => void;
+
+  /** Fired when the operator adds a new property to a record or
+   *  appends a new item to an array. For records, `keyOrIndex` is the
+   *  new key; for arrays, the new index (as a number). `initialValue`
+   *  is the default value for the picked type (empty string, `0`,
+   *  `false`, `null`, `{}`, or `[]`). */
+  onAddProperty?: (
+    path: string[],
+    keyOrIndex: string | number,
+    initialValue: unknown
+  ) => void;
+
+  /** Fired when the operator picks a new value-kind for an existing
+   *  row via the inline type picker. The DataView coerces the
+   *  existing value via {@link reqoreCoerceValueToKind} (preserves
+   *  content where it can; defaults for incompatible transitions)
+   *  and re-emits the tree via `onDataChange`. */
+  onChangeType?: (path: string[], kind: TReqoreDataValueKind) => void;
 }
 
 const SECTION_LABEL = (kind: 'Object' | 'List', count: number): string => {
@@ -155,6 +222,29 @@ type TRenderContext = {
   keyColor?: TReqoreEffectColor;
   /** Key-chip intent (defaults to `'info'`, `null` drops it). */
   keyIntent?: TReqoreIntent | null;
+  /** When true, scalar leaves render as click-to-edit chips, keys
+   *  are renamable, rows expose delete affordances, and containers
+   *  expose `+ Add` affordances. */
+  editable: boolean;
+  /** Commit a new scalar value at `path`. The owning `ReqoreDataView`
+   *  applies the immutable path-set and notifies the consumer via
+   *  `onDataChange`. */
+  commitScalar?: (path: string[], value: unknown) => void;
+  /** Remove the leaf at `path` (record key or array index). */
+  commitDelete?: (path: string[]) => void;
+  /** Rename a key on the record at `path`. Refused if `newKey`
+   *  already exists on that record. */
+  commitRename?: (path: string[], oldKey: string, newKey: string) => void;
+  /** Add a new entry to the record / array at `path`. */
+  commitAdd?: (
+    path: string[],
+    keyOrIndex: string | number,
+    initialValue: unknown
+  ) => void;
+  /** Coerce the leaf at `path` to a different value-kind. The owning
+   *  `ReqoreDataView` handles the conversion through
+   *  {@link reqoreCoerceValueToKind} and the immutable path-set. */
+  commitTypeChange?: (path: string[], kind: TReqoreDataValueKind) => void;
 };
 
 interface IStyledThemeProps {
@@ -221,13 +311,50 @@ const TableShell = styled.div<IStyledThemeProps & { $nested?: boolean }>`
 
 
 const Row = styled.div<
-  IStyledThemeProps & { $complex?: boolean; $odd?: boolean; $stacked?: boolean }
+  IStyledThemeProps & {
+    $complex?: boolean;
+    $odd?: boolean;
+    $stacked?: boolean;
+    $editable?: boolean;
+  }
 >`
   display: grid;
-  grid-template-columns: ${({ $complex, $stacked }) =>
-    $complex || $stacked
+  /* Grid columns + named areas together so children land in fixed
+     cells regardless of how many children render. Without
+     grid-template-areas, a 3-child row (key + value + actions) in a
+     2-column grid would auto-place the value into the actions
+     column. */
+  grid-template-columns: ${({ $complex, $stacked, $editable }) => {
+    const stacked = $complex || $stacked;
+    if ($editable) {
+      return stacked
+        ? 'minmax(0, 1fr) auto'
+        : 'minmax(120px, min(34%, 220px)) minmax(0, 1fr) auto';
+    }
+    return stacked
       ? 'minmax(0, 1fr)'
-      : 'minmax(120px, min(34%, 220px)) minmax(0, 1fr)'};
+      : 'minmax(120px, min(34%, 220px)) minmax(0, 1fr)';
+  }};
+  grid-template-areas: ${({ $complex, $stacked, $editable }) => {
+    const stacked = $complex || $stacked;
+    if ($editable) {
+      return stacked
+        ? `'key actions' 'value value'`
+        : `'key value actions'`;
+    }
+    return stacked ? `'key' 'value'` : `'key value'`;
+  }};
+
+  & > .reqore-data-view-key,
+  & > .reqore-data-view-key-edit-group {
+    grid-area: key;
+  }
+  & > .reqore-data-view-value-cell {
+    grid-area: value;
+  }
+  & > .reqore-data-view-row-actions {
+    grid-area: actions;
+  }
   gap: ${({ $size, $complex, $stacked }) =>
     $complex || $stacked ? GAP_FROM_SIZE[$size] : 8}px;
   align-items: start;
@@ -304,6 +431,14 @@ const ArrayStack = styled.div<IStyledThemeProps>`
 const ArrayItem = styled.div<IStyledThemeProps>`
   min-width: 0;
   max-width: 100%;
+  /* Two-column flex layout: content (index + value) on the left,
+     hover-revealed action cell on the right. Keeps the actions
+     properly inside the item's bounds instead of leaning on absolute
+     positioning. */
+  display: flex;
+  flex-flow: row;
+  align-items: start;
+  gap: 8px;
   /* More left padding than the other three sides so the item index
      and contents read as visually inset under the parent — mirrors
      the IDE pattern of "nested = inset". */
@@ -311,15 +446,18 @@ const ArrayItem = styled.div<IStyledThemeProps>`
     ${({ $size }) => PADDING_FROM_SIZE[$size]}px
     ${({ $size }) => PADDING_FROM_SIZE[$size]}px
     ${({ $size }) => PADDING_FROM_SIZE[$size] + 6}px;
-  /* Same depth model as nested TableShell — darker overlay, neutral
-     hairline border on three sides + a slightly more visible accent
-     on the left edge to read as a nested chunk. */
   border: 1px solid ${({ $theme }) => rgba(getReadableColor($theme), 0.08)};
   border-left: 2px solid ${({ $theme }) => rgba(getReadableColor($theme), 0.18)};
   border-radius: ${({ $size }) => RADIUS_FROM_SIZE[$size]}px;
-  /* Same depth as a nested TableShell (0.45) — an array item *is* a
-     nested chunk. */
   background: rgba(0, 0, 0, 0.45);
+`;
+
+/** Content column for an array item — wraps the item's index +
+ *  rendered value so the flex row's other cell (the action group)
+ *  sits to the right without competing for width. */
+const ArrayItemContent = styled.div`
+  flex: 1 1 auto;
+  min-width: 0;
 `;
 
 const ArrayItemIndex = styled.span<IStyledThemeProps>`
@@ -506,6 +644,684 @@ const PreservedDetails = memo(
 
 PreservedDetails.displayName = 'ReqoreDataView.PreservedDetails';
 
+/** Render the read-only value chip for a scalar leaf. Extracted so
+ *  both the read-only view and the click-to-edit cell share one
+ *  rendering — keeps the "before / after" look of an edited row
+ *  perfectly aligned with rows you can't edit. */
+const renderScalarChip = (
+  value: unknown,
+  type: string | undefined,
+  ctx: TRenderContext,
+  path: string[]
+): ReactNode => {
+  const scalar = reqoreFormatScalar(value, type, ctx.scalarOptions);
+  const kind = type ? reqoreDataValueKind(value, type) : scalar.kind;
+  const intent = reqoreDataValueIntent(kind);
+  return (
+    <ReqoreTag
+      size={ctx.size}
+      flat={false}
+      minimal
+      wrap
+      label={scalar.display}
+      intent={intent}
+      effect={{ weight: 'bold' }}
+      onClick={
+        ctx.onItemClick ? () => ctx.onItemClick!(value, path) : undefined
+      }
+      className='reqore-data-view-value'
+    />
+  );
+};
+
+const EditCellShell = styled.span<{ $editing?: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 100%;
+  cursor: ${({ $editing }) => ($editing ? 'text' : 'pointer')};
+
+  /* Subtle hover hint on the chip so operators know it's clickable —
+     without shouting. The chip itself doesn't gain border / shadow;
+     we just lift its outline a hair. */
+  &:not([data-editing='true']):hover .reqore-data-view-value {
+    outline: 1px dashed
+      ${({ theme }) =>
+        rgba(getReadableColor(theme as IReqoreTheme), 0.35)};
+    outline-offset: 1px;
+  }
+`;
+
+/** Click-to-edit scalar leaf. Renders the same read-only chip the
+ *  display view uses, until the operator clicks it — then swaps to an
+ *  input bound to a local draft. Commits on **blur** or **Enter**;
+ *  reverts on **Escape**. Booleans are special-cased to a checkbox
+ *  (toggle == edit; no separate edit mode needed).
+ *
+ *  The parent owns the data — committed values flow back via
+ *  `ctx.commitScalar(path, value)` and re-enter as new props on the
+ *  next render. */
+interface IEditableScalarCellProps {
+  value: unknown;
+  kind: TReqoreDataValueKind;
+  type?: string;
+  ctx: TRenderContext;
+  path: string[];
+}
+
+const initialDraftFor = (
+  value: unknown,
+  k: TReqoreDataValueKind
+): string | boolean => {
+  if (k === 'boolean') return value === true;
+  return value === null || value === undefined ? '' : String(value);
+};
+
+const EditableScalarCell = memo<IEditableScalarCellProps>(
+  ({ value, kind, type, ctx, path }) => {
+    const commit = ctx.commitScalar;
+
+    const isNumber = kind === 'number';
+    const isBoolean = kind === 'boolean';
+    const [editing, setEditing] = useState(false);
+    const [draft, setDraft] = useState<string | boolean>(
+      initialDraftFor(value, kind)
+    );
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    // Re-sync the local draft when the prop value or kind changes
+    // externally. Editing keeps its own draft until commit/cancel.
+    useLayoutEffect(() => {
+      if (editing) return;
+      setDraft(initialDraftFor(value, kind));
+    }, [value, kind, editing]);
+
+    // Focus the input when entering edit mode (text / number cells
+    // only — boolean's checkbox is keyboard-accessible by tab).
+    useLayoutEffect(() => {
+      if (!editing || isBoolean) return;
+      const node = inputRef.current;
+      if (!node) return;
+      node.focus();
+      node.select?.();
+    }, [editing, isBoolean]);
+
+    const startEditing = useCallback(() => {
+      if (!commit) return;
+      setDraft(initialDraftFor(value, kind));
+      setEditing(true);
+    }, [commit, kind, value]);
+
+    const cancelEditing = useCallback(() => {
+      setDraft(initialDraftFor(value, kind));
+      setEditing(false);
+    }, [kind, value]);
+
+    const commitDraft = useCallback(() => {
+      if (!commit) {
+        setEditing(false);
+        return;
+      }
+      if (isBoolean) {
+        commit(path, draft === true);
+        setEditing(false);
+        return;
+      }
+      const text = typeof draft === 'string' ? draft : '';
+      if (isNumber) {
+        if (text.trim() === '') {
+          commit(path, null);
+          setEditing(false);
+          return;
+        }
+        const parsed = Number(text);
+        if (Number.isNaN(parsed)) {
+          cancelEditing();
+          return;
+        }
+        commit(path, parsed);
+        setEditing(false);
+        return;
+      }
+      // String / null cells. An empty edit on a null leaf is a no-op
+      // (don't accidentally upgrade null → empty string).
+      if (text === '' && (value === null || value === undefined)) {
+        setEditing(false);
+        return;
+      }
+      commit(path, text);
+      setEditing(false);
+    }, [cancelEditing, commit, draft, isBoolean, isNumber, path, value]);
+
+    if (!editing) {
+      return (
+        <EditCellShell
+          data-editing='false'
+          onClick={(e) => {
+            e.stopPropagation();
+            startEditing();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              startEditing();
+            }
+          }}
+          role='button'
+          tabIndex={0}
+          aria-label='Edit value'
+        >
+          {renderScalarChip(value, type, ctx, path)}
+        </EditCellShell>
+      );
+    }
+
+    // Inline type-change. Coerces the CURRENT DRAFT (in its
+    // canonical form for the current kind — string for text/numeric
+    // inputs, boolean for the checkbox) to the picked kind. A user
+    // who has typed `42` and then realises they meant Number keeps
+    // the `42` they typed; a user who has clicked the checkbox `on`
+    // and switches to String gets `"true"`.
+    //
+    // Picking `string` / `number` / `boolean` keeps the cell in edit
+    // mode and re-initialises the draft to the coerced value (so the
+    // input swap doesn't visually drop the user's intent). Picking
+    // `object` / `array` / `null` commits the coerced value and
+    // exits so the right control takes over (structural view / "—"
+    // chip).
+    const handlePickType = (newKind: TReqoreDataValueKind) => {
+      if (newKind === kind) return;
+      const coerced = reqoreCoerceValueToKind(draft, newKind);
+      ctx.commitTypeChange?.(path, newKind);
+      if (newKind === 'string' || newKind === 'number') {
+        setDraft(coerced === null || coerced === undefined ? '' : String(coerced));
+      } else if (newKind === 'boolean') {
+        setDraft(coerced === true);
+      } else {
+        setEditing(false);
+      }
+    };
+
+    const currentTypeItem = TYPE_PICKER_ITEMS.find(
+      (entry) => entry.kind === kind
+    );
+
+    return (
+      <ReqoreControlGroup
+        gapSize='tiny'
+        verticalAlign='center'
+        size={ctx.size}
+        className='reqore-data-view-edit-group'
+      >
+        {isBoolean ? (
+          <ReqoreCheckbox
+            checked={draft === true}
+            size={ctx.size}
+            // Toggle the LOCAL draft only — Save commits, Cancel
+            // discards. Keeps the edit semantics identical to
+            // text/number cells.
+            onClick={() => setDraft(!(draft === true))}
+            className='reqore-data-view-edit-bool'
+          />
+        ) : (
+          <ReqoreInput
+            size={ctx.size}
+            type={isNumber ? 'number' : 'text'}
+            value={typeof draft === 'string' ? draft : ''}
+            ref={
+              ((node: { _input?: HTMLInputElement } | HTMLDivElement | null) => {
+                if (node instanceof HTMLElement) {
+                  inputRef.current = node.querySelector('input');
+                }
+              }) as unknown as React.Ref<HTMLDivElement>
+            }
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+              setDraft(event.target.value)
+            }
+            onBlur={commitDraft}
+            onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                commitDraft();
+              } else if (event.key === 'Escape') {
+                event.preventDefault();
+                cancelEditing();
+              }
+            }}
+            className='reqore-data-view-edit'
+          />
+        )}
+        {/* Inline type picker — only visible while editing. The
+            trigger shows the CURRENT kind so the operator reads the
+            row as "I'm editing X, currently typed as Y; want to
+            change?" rather than picking a brand-new type blind. */}
+        {ctx.commitTypeChange ? (
+          <ReqoreDropdown
+            size={ctx.size}
+            icon={currentTypeItem?.icon ?? 'TextWrap'}
+            tooltip='Change type'
+            className='reqore-data-view-edit-type'
+            items={TYPE_PICKER_ITEMS.map((entry) => ({
+              label: entry.label,
+              icon: entry.icon,
+              selected: entry.kind === kind,
+              onClick: () => handlePickType(entry.kind),
+            }))}
+          />
+        ) : null}
+        {/* Save / Cancel use `onMouseDown` with `preventDefault` so
+            clicking them doesn't first blur-commit the input — the
+            action you clicked is the action that fires. */}
+        <ReqoreButton
+          size={ctx.size}
+          icon='CheckLine'
+          intent='success'
+          flat
+          minimal
+          tooltip='Save (Enter)'
+          onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) => {
+            e.preventDefault();
+            commitDraft();
+          }}
+          className='reqore-data-view-edit-commit'
+        />
+        <ReqoreButton
+          size={ctx.size}
+          icon='CloseLine'
+          flat
+          minimal
+          tooltip='Cancel (Esc)'
+          onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) => {
+            e.preventDefault();
+            cancelEditing();
+          }}
+          className='reqore-data-view-edit-cancel'
+        />
+      </ReqoreControlGroup>
+    );
+  }
+);
+EditableScalarCell.displayName = 'ReqoreDataView.EditableScalarCell';
+
+/** Click-to-edit key cell — swaps the static key tag for an input on
+ *  click, then commits via `ctx.commitRename`. The owning RecordTable
+ *  rejects duplicate keys before the commit reaches the parent. */
+interface IEditableKeyCellProps {
+  keyName: string;
+  siblingKeys: ReadonlyArray<string>;
+  parentPath: string[];
+  ctx: TRenderContext;
+}
+
+const EditableKeyCell = memo<IEditableKeyCellProps>(
+  ({ keyName, siblingKeys, parentPath, ctx }) => {
+    const commit = ctx.commitRename;
+    const [editing, setEditing] = useState(false);
+    const [draft, setDraft] = useState(keyName);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    useLayoutEffect(() => {
+      if (editing) return;
+      setDraft(keyName);
+    }, [keyName, editing]);
+
+    useLayoutEffect(() => {
+      if (!editing) return;
+      const node = inputRef.current;
+      if (!node) return;
+      node.focus();
+      node.select?.();
+    }, [editing]);
+
+    const start = useCallback(() => {
+      if (!commit) return;
+      setDraft(keyName);
+      setEditing(true);
+    }, [commit, keyName]);
+    const cancel = useCallback(() => {
+      setDraft(keyName);
+      setEditing(false);
+    }, [keyName]);
+    const submit = useCallback(() => {
+      const trimmed = draft.trim();
+      if (!commit || !trimmed || trimmed === keyName) {
+        cancel();
+        return;
+      }
+      if (siblingKeys.includes(trimmed)) {
+        cancel();
+        return;
+      }
+      commit(parentPath, keyName, trimmed);
+      setEditing(false);
+    }, [cancel, commit, draft, keyName, parentPath, siblingKeys]);
+
+    if (!editing) {
+      return (
+        <EditCellShell
+          data-editing='false'
+          onClick={(e) => {
+            e.stopPropagation();
+            start();
+          }}
+          role='button'
+          tabIndex={0}
+          aria-label='Rename key'
+        >
+          <ReqoreTag
+            size={ctx.size}
+            flat={false}
+            minimal
+            wrap
+            intent={ctx.keyIntent === null ? undefined : ctx.keyIntent ?? 'info'}
+            color={ctx.keyColor}
+            label={keyName}
+            effect={{ weight: 'bold' }}
+            className='reqore-data-view-key'
+          />
+        </EditCellShell>
+      );
+    }
+
+    return (
+      <ReqoreControlGroup
+        gapSize='tiny'
+        verticalAlign='center'
+        size={ctx.size}
+        className='reqore-data-view-key-edit-group'
+      >
+        <ReqoreInput
+          size={ctx.size}
+          value={draft}
+          ref={
+            ((node: HTMLDivElement | null) => {
+              if (node instanceof HTMLElement) {
+                inputRef.current = node.querySelector('input');
+              }
+            }) as unknown as React.Ref<HTMLDivElement>
+          }
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setDraft(e.target.value)
+          }
+          onBlur={submit}
+          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              submit();
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              cancel();
+            }
+          }}
+          className='reqore-data-view-key-edit'
+        />
+        <ReqoreButton
+          size={ctx.size}
+          icon='CheckLine'
+          intent='success'
+          flat
+          minimal
+          tooltip='Rename (Enter)'
+          onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) => {
+            e.preventDefault();
+            submit();
+          }}
+          className='reqore-data-view-key-edit-commit'
+        />
+        <ReqoreButton
+          size={ctx.size}
+          icon='CloseLine'
+          flat
+          minimal
+          tooltip='Cancel (Esc)'
+          onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) => {
+            e.preventDefault();
+            cancel();
+          }}
+          className='reqore-data-view-key-edit-cancel'
+        />
+      </ReqoreControlGroup>
+    );
+  }
+);
+EditableKeyCell.displayName = 'ReqoreDataView.EditableKeyCell';
+
+/** Hover-revealed row action group — currently the delete button.
+ *  Renders as a normal grid cell at the trailing edge of each row so
+ *  it always sits cleanly inside the row's bounds (no absolute
+ *  positioning, no overflow past the panel's rounded corner). The
+ *  group's `opacity` is `0` by default and promoted to `1` on row
+ *  hover via the parent `Row`'s `:hover` rule. The cell itself stays
+ *  in the layout so the row width doesn't jump as the user hovers. */
+const RowActionsContainer = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  /* Pad the action cell off the row's right edge a touch so the button
+     doesn't kiss the panel's rounded corner. */
+  padding-right: 2px;
+  opacity: 0;
+  transition: opacity 0.12s ease-out;
+  pointer-events: none;
+
+  .reqore-data-view-row:hover & {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  /* Keep the actions visible when any child is focused (keyboard
+     navigation must reveal them too). */
+  &:focus-within {
+    opacity: 1;
+    pointer-events: auto;
+  }
+`;
+
+/** Row-level action group. Only the delete affordance lives here —
+ *  type-changing is a per-value editing concern and ships inside the
+ *  edit-mode ControlGroup instead, so the always-visible row actions
+ *  stay purely structural. */
+interface IRowActionsProps {
+  ctx: TRenderContext;
+  path: string[];
+  ariaLabel: string;
+}
+
+const RowActions = memo<IRowActionsProps>(({ ctx, path, ariaLabel }) => {
+  if (!ctx.commitDelete) return null;
+  return (
+    <RowActionsContainer
+      className='reqore-data-view-row-actions'
+      onClick={(e) => e.stopPropagation()}
+    >
+      <ReqoreButton
+        size={ctx.size}
+        icon='DeleteBin6Line'
+        flat
+        minimal
+        tooltip={ariaLabel}
+        intent='danger'
+        onClick={() => ctx.commitDelete!(path)}
+        className='reqore-data-view-row-delete'
+      />
+    </RowActionsContainer>
+  );
+});
+RowActions.displayName = 'ReqoreDataView.RowActions';
+
+/** Default value for a new entry of the picked type. */
+const defaultForKind = (kind: TReqoreDataValueKind): unknown => {
+  switch (kind) {
+    case 'string':
+      return '';
+    case 'number':
+      return 0;
+    case 'boolean':
+      return false;
+    case 'object':
+      return {};
+    case 'array':
+      return [];
+    case 'null':
+    default:
+      return null;
+  }
+};
+
+const TYPE_PICKER_ITEMS: Array<{
+  kind: TReqoreDataValueKind;
+  label: string;
+  icon: 'TextWrap' | 'Hashtag' | 'CheckboxLine' | 'BracesLine' | 'BracketsLine' | 'CircleLine';
+}> = [
+  { kind: 'string', label: 'String', icon: 'TextWrap' },
+  { kind: 'number', label: 'Number', icon: 'Hashtag' },
+  { kind: 'boolean', label: 'Boolean', icon: 'CheckboxLine' },
+  { kind: 'object', label: 'Object (hash)', icon: 'BracesLine' },
+  { kind: 'array', label: 'Array (list)', icon: 'BracketsLine' },
+  { kind: 'null', label: 'Null', icon: 'CircleLine' },
+];
+
+const AddRowShell = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  gap: 6px;
+  align-items: center;
+  padding: 8px;
+  border-top: 1px dashed
+    ${({ theme }) => rgba(getReadableColor(theme as IReqoreTheme), 0.2)};
+  background: rgba(0, 0, 0, 0.12);
+`;
+
+/** Inline `+ Add property` / `+ Add item` affordance.
+ *
+ *  Renders as a trailing button at the end of a record / array. Click
+ *  the button → expands to a form: a key input (records only) + a
+ *  type-picker dropdown + commit / cancel buttons. Submitting fires
+ *  `ctx.commitAdd(parentPath, key|index, defaultForKind(kind))`.
+ *
+ *  Records: rejects empty / duplicate keys.
+ *  Arrays:  appends to the next index. */
+interface IAddEntryAffordanceProps {
+  ctx: TRenderContext;
+  parentPath: string[];
+  /** Existing keys (records) or existing length (arrays). */
+  context:
+    | { kind: 'record'; existingKeys: ReadonlyArray<string> }
+    | { kind: 'array'; length: number };
+}
+
+const AddEntryAffordance = memo<IAddEntryAffordanceProps>(
+  ({ ctx, parentPath, context }) => {
+    const [open, setOpen] = useState(false);
+    const [key, setKey] = useState('');
+    const [valueKind, setValueKind] = useState<TReqoreDataValueKind>('string');
+
+    if (!ctx.commitAdd) return null;
+
+    const reset = () => {
+      setOpen(false);
+      setKey('');
+      setValueKind('string');
+    };
+
+    const submit = () => {
+      const initial = defaultForKind(valueKind);
+      if (context.kind === 'record') {
+        const trimmed = key.trim();
+        if (!trimmed) return;
+        if (context.existingKeys.includes(trimmed)) return;
+        ctx.commitAdd!(parentPath, trimmed, initial);
+      } else {
+        ctx.commitAdd!(parentPath, context.length, initial);
+      }
+      reset();
+    };
+
+    if (!open) {
+      return (
+        <AddRowShell
+          className='reqore-data-view-add-row'
+          data-state='collapsed'
+        >
+          <ReqoreButton
+            size={ctx.size}
+            icon='AddLine'
+            flat
+            minimal
+            onClick={() => setOpen(true)}
+            label={context.kind === 'record' ? 'Add property' : 'Add item'}
+          />
+        </AddRowShell>
+      );
+    }
+
+    const typeItem = TYPE_PICKER_ITEMS.find((entry) => entry.kind === valueKind);
+
+    return (
+      <AddRowShell
+        className='reqore-data-view-add-row'
+        data-state='expanded'
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault();
+            reset();
+          }
+        }}
+      >
+        {context.kind === 'record' ? (
+          <ReqoreInput
+            size={ctx.size}
+            placeholder='property name'
+            value={key}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setKey(e.target.value)
+            }
+            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                submit();
+              }
+            }}
+            className='reqore-data-view-add-key'
+          />
+        ) : null}
+        <ReqoreDropdown
+          size={ctx.size}
+          icon={typeItem?.icon}
+          label={typeItem?.label ?? 'String'}
+          className='reqore-data-view-add-type'
+          items={TYPE_PICKER_ITEMS.map((entry) => ({
+            label: entry.label,
+            icon: entry.icon,
+            selected: entry.kind === valueKind,
+            onClick: () => setValueKind(entry.kind),
+          }))}
+        />
+        <ReqoreButton
+          size={ctx.size}
+          icon='CheckLine'
+          intent='success'
+          flat
+          minimal
+          onClick={submit}
+          label='Add'
+          className='reqore-data-view-add-commit'
+        />
+        <ReqoreButton
+          size={ctx.size}
+          icon='CloseLine'
+          flat
+          minimal
+          onClick={reset}
+          tooltip='Cancel'
+          className='reqore-data-view-add-cancel'
+        />
+      </AddRowShell>
+    );
+  }
+);
+AddEntryAffordance.displayName = 'ReqoreDataView.AddEntryAffordance';
+
 const isInlineableScalarValue = (
   value: unknown,
   ctx: TRenderContext
@@ -527,6 +1343,35 @@ const renderScalar = (
   const kind = type ? reqoreDataValueKind(value, type) : scalar.kind;
   const intent = reqoreDataValueIntent(kind);
   const displayType = type ?? kind;
+
+  // Editable mode: render the click-to-edit cell instead of the
+  // static chip. Date-typed scalars stay read-only until the date
+  // picker lands.
+  if (ctx.editable && kind !== 'date' && kind !== 'object' && kind !== 'array') {
+    const cell = (
+      <EditableScalarCell
+        value={value}
+        kind={kind}
+        type={type}
+        ctx={ctx}
+        path={path}
+      />
+    );
+    if (!ctx.showTypes || !displayType) return cell;
+    return (
+      <ScalarRow gapSize='tiny' verticalAlign='center' size={ctx.size}>
+        {cell}
+        <ReqoreTag
+          size={ctx.size}
+          flat
+          minimal
+          label={displayType}
+          effect={{ uppercase: true, spaced: 1, opacity: 0.6 }}
+          className='reqore-data-view-type'
+        />
+      </ScalarRow>
+    );
+  }
 
   // Value chip: minimal + intent-tinted (so the type is colour-coded
   // without shouting), weight bold. We always render with a border
@@ -621,6 +1466,8 @@ const RecordTable = memo(
       return () => observer.disconnect();
     }, []);
 
+    const siblingKeys = entries.map(([k]) => k);
+
     return (
       <TableShell
         ref={shellRef}
@@ -644,6 +1491,7 @@ const RecordTable = memo(
                   : (reqoreUnwrapEnvelope(item, ctx.envelope) as unknown[])
                 ).every((entry) => isInlineableScalarValue(entry, ctx))
               ));
+          const rowPath = [...path, key];
           return (
             <Row
               key={`${path.join('.')}-${key}`}
@@ -652,30 +1500,54 @@ const RecordTable = memo(
               $complex={complex}
               $odd={index % 2 === 0}
               $stacked={stacked}
+              $editable={ctx.editable}
               className='reqore-data-view-row'
             >
-              <ReqoreTag
-                size={ctx.size}
-                flat={false}
-                minimal
-                wrap
-                intent={ctx.keyIntent === null ? undefined : ctx.keyIntent ?? 'info'}
-                color={ctx.keyColor}
-                label={key}
-                effect={{ weight: 'bold' }}
-                className='reqore-data-view-key'
-              />
+              {ctx.editable ? (
+                <EditableKeyCell
+                  keyName={key}
+                  siblingKeys={siblingKeys}
+                  parentPath={path}
+                  ctx={ctx}
+                />
+              ) : (
+                <ReqoreTag
+                  size={ctx.size}
+                  flat={false}
+                  minimal
+                  wrap
+                  intent={ctx.keyIntent === null ? undefined : ctx.keyIntent ?? 'info'}
+                  color={ctx.keyColor}
+                  label={key}
+                  effect={{ weight: 'bold' }}
+                  className='reqore-data-view-key'
+                />
+              )}
               <ValueCell
                 $size={ctx.size}
                 $theme={theme}
                 $complex={complex}
                 className='reqore-data-view-value-cell'
               >
-                {renderTree(item, ctx, theme, depth + 1, [...path, key])}
+                {renderTree(item, ctx, theme, depth + 1, rowPath)}
               </ValueCell>
+              {ctx.editable ? (
+                <RowActions
+                  ctx={ctx}
+                  path={rowPath}
+                  ariaLabel={`Remove ${key}`}
+                />
+              ) : null}
             </Row>
           );
         })}
+        {ctx.editable ? (
+          <AddEntryAffordance
+            ctx={ctx}
+            parentPath={path}
+            context={{ kind: 'record', existingKeys: siblingKeys }}
+          />
+        ) : null}
       </TableShell>
     );
   }
@@ -711,8 +1583,13 @@ const renderTree = (
 
   // Arrays.
   if (Array.isArray(unwrapped)) {
+    // In editable mode, render every array item as its own row so the
+    // hover-revealed delete + `+ Add item` affordance has a place to
+    // live. The inline chip-row variant is for read-only density.
     const allInlineable =
-      ctx.inlineScalarArrays && unwrapped.every((item) => isInlineableScalarValue(item, ctx));
+      !ctx.editable &&
+      ctx.inlineScalarArrays &&
+      unwrapped.every((item) => isInlineableScalarValue(item, ctx));
 
     if (allInlineable) {
       return (
@@ -743,21 +1620,40 @@ const renderTree = (
 
     const content = (
       <ArrayStack $size={ctx.size} $theme={theme} className='reqore-data-view-array'>
-        {unwrapped.map((item, index) => (
-          <ArrayItem
-            key={`${path.join('.')}-${index}`}
-            $size={ctx.size}
-            $theme={theme}
-            className='reqore-data-view-array-item'
-          >
-            {unwrapped.length > 1 ? (
-              <ArrayItemIndex $size={ctx.size} $theme={theme}>
-                {index + 1}
-              </ArrayItemIndex>
-            ) : null}
-            {renderTree(item, ctx, theme, depth + 1, [...path, String(index)])}
-          </ArrayItem>
-        ))}
+        {unwrapped.map((item, index) => {
+          const itemPath = [...path, String(index)];
+          return (
+            <ArrayItem
+              key={`${path.join('.')}-${index}`}
+              $size={ctx.size}
+              $theme={theme}
+              className='reqore-data-view-array-item reqore-data-view-row'
+            >
+              <ArrayItemContent>
+                {unwrapped.length > 1 ? (
+                  <ArrayItemIndex $size={ctx.size} $theme={theme}>
+                    {index + 1}
+                  </ArrayItemIndex>
+                ) : null}
+                {renderTree(item, ctx, theme, depth + 1, itemPath)}
+              </ArrayItemContent>
+              {ctx.editable ? (
+                <RowActions
+                  ctx={ctx}
+                  path={itemPath}
+                  ariaLabel={`Remove item ${index + 1}`}
+                />
+              ) : null}
+            </ArrayItem>
+          );
+        })}
+        {ctx.editable ? (
+          <AddEntryAffordance
+            ctx={ctx}
+            parentPath={path}
+            context={{ kind: 'array', length: unwrapped.length }}
+          />
+        ) : null}
       </ArrayStack>
     );
 
@@ -827,6 +1723,13 @@ export const ReqoreDataView = memo(
         onSectionToggle,
         keyColor,
         keyIntent,
+        editable = false,
+        onDataChange,
+        onValueChange,
+        onRemoveProperty,
+        onRenameProperty,
+        onAddProperty,
+        onChangeType,
         size = 'normal',
         customTheme,
         inheritCustomTheme,
@@ -844,9 +1747,103 @@ export const ReqoreDataView = memo(
         inheritCustomTheme
       );
 
-      const empty = !reqoreHasStructuredValue(
-        data,
-        envelope === false ? undefined : envelope
+      // In editable mode an empty `{}` or `[]` must still render the
+      // tree so the `+ Add property` / `+ Add item` affordance is
+      // reachable — otherwise a from-scratch build is impossible.
+      // Only fall back to the empty callout when read-only AND the
+      // value is genuinely empty.
+      const empty =
+        !editable &&
+        !reqoreHasStructuredValue(
+          data,
+          envelope === false ? undefined : envelope
+        );
+
+      const dataRef = useRef(data);
+      useLayoutEffect(() => {
+        dataRef.current = data;
+      }, [data]);
+
+      const commitScalar = useCallback(
+        (path: string[], value: unknown) => {
+          onValueChange?.(path, value);
+          if (!onDataChange) return;
+          const next = reqoreSetAtPath(dataRef.current, path, value);
+          onDataChange(next);
+        },
+        [onDataChange, onValueChange]
+      );
+
+      const commitDelete = useCallback(
+        (path: string[]) => {
+          onRemoveProperty?.(path);
+          if (!onDataChange) return;
+          const next = reqoreDeleteAtPath(dataRef.current, path);
+          onDataChange(next);
+        },
+        [onDataChange, onRemoveProperty]
+      );
+
+      const commitRename = useCallback(
+        (parentPath: string[], oldKey: string, newKey: string) => {
+          onRenameProperty?.(parentPath, oldKey, newKey);
+          if (!onDataChange) return;
+          const next = reqoreRenameKeyAtPath(
+            dataRef.current,
+            parentPath,
+            oldKey,
+            newKey
+          );
+          onDataChange(next);
+        },
+        [onDataChange, onRenameProperty]
+      );
+
+      const commitAdd = useCallback(
+        (
+          parentPath: string[],
+          keyOrIndex: string | number,
+          initialValue: unknown
+        ) => {
+          onAddProperty?.(parentPath, keyOrIndex, initialValue);
+          if (!onDataChange) return;
+          const next = reqoreSetAtPath(
+            dataRef.current,
+            [...parentPath, String(keyOrIndex)],
+            initialValue
+          );
+          onDataChange(next);
+        },
+        [onAddProperty, onDataChange]
+      );
+
+      const commitTypeChange = useCallback(
+        (path: string[], kind: TReqoreDataValueKind) => {
+          onChangeType?.(path, kind);
+          if (!onDataChange) return;
+          // Read the current value at path, coerce it to the target
+          // kind, and re-emit the tree. The lookup walks the same
+          // path the set will use, so a missing path is a no-op.
+          let current: unknown = dataRef.current;
+          for (const segment of path) {
+            if (current == null) return;
+            if (Array.isArray(current)) {
+              const index = Number.parseInt(segment, 10);
+              current = Number.isNaN(index) ? undefined : current[index];
+            } else if (reqoreIsRecord(current)) {
+              current = current[segment];
+            } else {
+              return;
+            }
+          }
+          const next = reqoreSetAtPath(
+            dataRef.current,
+            path,
+            reqoreCoerceValueToKind(current, kind)
+          );
+          onDataChange(next);
+        },
+        [onChangeType, onDataChange]
       );
 
       const ctx: TRenderContext = {
@@ -861,6 +1858,12 @@ export const ReqoreDataView = memo(
         onSectionToggle,
         keyColor,
         keyIntent,
+        editable,
+        commitScalar: editable ? commitScalar : undefined,
+        commitDelete: editable ? commitDelete : undefined,
+        commitRename: editable ? commitRename : undefined,
+        commitAdd: editable ? commitAdd : undefined,
+        commitTypeChange: editable ? commitTypeChange : undefined,
       };
 
       const body = empty ? (
@@ -915,12 +1918,16 @@ export const ReqoreDataView = memo(
 export type { IReqoreDataViewEmbedded, IReqoreDataViewEnvelope } from './helpers';
 export {
   DEFAULT_ENVELOPE,
+  reqoreCoerceValueToKind,
   reqoreDataValueIntent,
   reqoreDataValueKind,
+  reqoreDeleteAtPath,
   reqoreEnvelopeType,
   reqoreFormatScalar,
   reqoreHasStructuredValue,
   reqoreIsEnvelope,
   reqoreIsRecord,
+  reqoreRenameKeyAtPath,
+  reqoreSetAtPath,
   reqoreUnwrapEnvelope,
 } from './helpers';

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -15,6 +15,7 @@ import { IReqoreTheme } from '../../constants/theme';
 import { changeLightness, getReadableColor } from '../../helpers/colors';
 import { IReqoreAutoFocusRules, useAutoFocus } from '../../hooks/useAutoFocus';
 import { useCombinedRefs } from '../../hooks/useCombinedRefs';
+import { useReqoreProperty } from '../../hooks/useReqoreContext';
 import { useReqoreTheme } from '../../hooks/useTheme';
 import { ActiveIconScale, DisabledElement, InactiveIconScale, ReadOnlyElement } from '../../styles';
 import {
@@ -30,6 +31,7 @@ import { IReqoreIconName } from '../../types/icons';
 import { StyledEffect, TReqoreEffectColor } from '../Effect';
 import ReqoreIcon, { IReqoreIconProps } from '../Icon';
 import ReqoreInputClearButton from '../InputClearButton';
+import { ReqoreKeyboardShortcut } from '../KeyboardShortcut';
 import { ReqoreTooltipComponent } from '../TooltipComponent';
 
 export interface IReqoreInputProps
@@ -68,6 +70,11 @@ export interface IReqoreInputProps
   iconColor?: TReqoreEffectColor;
   rightIconColor?: TReqoreEffectColor;
   focusRules?: IReqoreAutoFocusRules;
+  /**
+   * Whether to render a badge-style hint for the `focusRules` keyboard shortcut.
+   * Defaults to `true`, unless globally disabled via the `shortcutHints` UI option.
+   */
+  shortcutHint?: boolean;
 
   leftIconProps?: IReqoreIconProps;
   rightIconProps?: IReqoreIconProps;
@@ -83,6 +90,7 @@ export interface IReqoreInputStyle extends IReqoreInputProps {
   _size?: TSizes;
   clearable?: boolean;
   hasIcon?: boolean;
+  hasShortcutHint?: boolean;
 }
 
 export const StyledInputWrapper = styled.div<IReqoreInputStyle>`
@@ -125,19 +133,34 @@ const StyledIconWrapper = styled.div<IReqoreInputStyle>`
   align-items: center;
 `;
 
+const StyledShortcutWrapper = styled.div<{ _size: TSizes; offset: number }>`
+  position: absolute;
+  height: 100%;
+  top: 0;
+  right: ${({ offset }) => offset}px;
+  display: flex;
+  align-items: center;
+  pointer-events: none;
+`;
+
 export const StyledInput = styled(StyledEffect)<IReqoreInputStyle>`
   height: 100%;
   width: 100%;
   flex: 1;
   margin: 0;
   padding: ${({ _size }) => PADDING_FROM_SIZE[_size] / 2}px 7px;
-  padding-right: ${({ clearable, hasRightIcon, _size }) => {
+  padding-right: ${({ clearable, hasRightIcon, hasShortcutHint, _size }) => {
     let padding = 7;
 
     if (clearable || hasRightIcon) {
       padding = 0;
       padding += clearable ? SIZE_TO_PX[_size] : 0;
       padding += hasRightIcon ? SIZE_TO_PX[_size] : 0;
+    }
+
+    // Reserve room so typed text / placeholder doesn't slide under the hint badge.
+    if (hasShortcutHint) {
+      padding += SIZE_TO_PX[_size];
     }
 
     return padding;
@@ -221,6 +244,7 @@ const ReqoreInput = forwardRef<HTMLDivElement, IReqoreInputProps>(
       intent,
       wrapperStyle,
       focusRules,
+      shortcutHint,
       leftIconProps = {},
       rightIconProps = {},
       pill,
@@ -233,11 +257,22 @@ const ReqoreInput = forwardRef<HTMLDivElement, IReqoreInputProps>(
     const { targetRef } = useCombinedRefs(ref);
     const [inputRef, setInputRef] = useState<HTMLInputElement>(null);
     const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
+    const shortcutHintsEnabled = useReqoreProperty('shortcutHints');
 
     useAutoFocus(inputRef, readOnly || rest.disabled ? undefined : focusRules, rest.onChange);
 
     const hasLeftIcon = icon || leftIconProps?.image;
     const hasRightIcon = rightIcon || rightIconProps?.image;
+    const clearable =
+      !rest?.disabled &&
+      !readOnly &&
+      !!(onClearClick && (rest.as || rest.children || rest?.onChange));
+    const showShortcutHint =
+      !!focusRules?.shortcut &&
+      shortcutHint !== false &&
+      shortcutHintsEnabled !== false &&
+      !readOnly &&
+      !rest.disabled;
     const leftIcon: IReqoreIconName = loading
       ? `Loader${loadingIconType || ''}Line`
       : icon || leftIconProps?.icon;
@@ -290,11 +325,8 @@ const ReqoreInput = forwardRef<HTMLDivElement, IReqoreInputProps>(
           rounded={rounded}
           hasIcon={!!icon}
           hasRightIcon={!!rightIcon}
-          clearable={
-            !rest?.disabled &&
-            !readOnly &&
-            !!(onClearClick && (rest.as || rest.children || rest?.onChange))
-          }
+          hasShortcutHint={showShortcutHint}
+          clearable={clearable}
           className={`${className || ''} reqore-control reqore-input`}
           readOnly={readOnly || loading}
           pill={pill}
@@ -302,11 +334,7 @@ const ReqoreInput = forwardRef<HTMLDivElement, IReqoreInputProps>(
           {rest?.children}
         </StyledInput>
         <ReqoreInputClearButton
-          enabled={
-            !readOnly &&
-            !rest?.disabled &&
-            !!(onClearClick && (rest.as || rest.children || rest?.onChange))
-          }
+          enabled={clearable}
           onClick={onClearClick}
           hasRightIcon={!!rightIcon}
           size={size}
@@ -322,6 +350,14 @@ const ReqoreInput = forwardRef<HTMLDivElement, IReqoreInputProps>(
               {...rightIconProps}
             />
           </StyledIconWrapper>
+        )}
+        {showShortcutHint && (
+          <StyledShortcutWrapper
+            _size={size}
+            offset={(hasRightIcon ? SIZE_TO_PX[size] : 0) + (clearable ? SIZE_TO_PX[size] : 0) + 7}
+          >
+            <ReqoreKeyboardShortcut shortcut={focusRules.shortcut} size={size} compact />
+          </StyledShortcutWrapper>
         )}
       </ReqoreTooltipComponent>
     );

--- a/src/components/KeyboardShortcut/index.tsx
+++ b/src/components/KeyboardShortcut/index.tsx
@@ -1,0 +1,122 @@
+import { memo, useMemo } from 'react';
+import { rgba } from 'polished';
+import styled from 'styled-components';
+import {
+  BADGE_RADIUS_FROM_SIZE,
+  BADGE_SIZE_TO_PX,
+  GAP_FROM_SIZE,
+  PADDING_FROM_SIZE,
+  TAG_TEXT_FROM_SIZE,
+  TSizes,
+} from '../../constants/sizes';
+import { formatShortcut, TReqoreKeyboardShortcut } from '../../helpers/shortcuts';
+import { getOneLessSize } from '../../helpers/utils';
+
+export interface IReqoreKeyboardShortcutProps {
+  /**
+   * The shortcut to display, following the `react-hotkeys-hook` syntax
+   * (e.g. `'mod+k'`, `'ctrl+shift+s'`, or `['mod+k', 'ctrl+k']`). The `mod`
+   * modifier renders as `⌘` on macOS and `Ctrl` elsewhere.
+   */
+  shortcut: TReqoreKeyboardShortcut;
+  size?: TSizes;
+  /**
+   * Render the badge one size smaller than `size` so it sits unobtrusively
+   * inside a control. Defaults to `true`.
+   */
+  oneLessSize?: boolean;
+  /**
+   * Override the chip colour. Defaults to `currentColor` so the chip adapts to
+   * the foreground colour of whatever surface it sits on (button label, input
+   * text, etc.) — this keeps it readable on intent-coloured buttons.
+   */
+  color?: string;
+  compact?: boolean;
+  wrap?: boolean;
+  className?: string;
+}
+
+interface IStyledShortcutKey {
+  _size: TSizes;
+  compact?: boolean;
+  color?: string;
+}
+
+const StyledShortcutKey = styled.span<IStyledShortcutKey>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  height: ${({ _size }) => BADGE_SIZE_TO_PX[_size]}px;
+  min-width: ${({ _size }) => BADGE_SIZE_TO_PX[_size]}px;
+  padding: 0 ${({ _size, compact }) => PADDING_FROM_SIZE[_size] / (compact ? 3 : 2)}px;
+  font-size: ${({ _size }) => TAG_TEXT_FROM_SIZE[_size]}px;
+  font-family: system-ui;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  border-radius: ${({ _size }) => BADGE_RADIUS_FROM_SIZE[_size]}px;
+
+  // currentColor lets the chip's text/border inherit the surrounding text
+  // colour, so it stays readable on any surface. The fill is a subtle dark
+  // overlay (or a tint of the color prop when provided) to give it definition.
+  color: ${({ color }) => color || 'currentColor'};
+  border: 1px solid ${({ color }) => (color ? rgba(color, 0.4) : 'currentColor')};
+  background-color: ${({ color }) => (color ? rgba(color, 0.12) : rgba('#000000', 0.3))};
+  opacity: ${({ color }) => (color ? 1 : 0.85)};
+`;
+
+const StyledShortcutGroup = styled.span<{ _size: TSizes; wrap?: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: ${({ wrap }) => (wrap ? 'wrap' : 'nowrap')};
+  gap: ${({ _size }) => GAP_FROM_SIZE[_size]}px;
+`;
+
+/**
+ * Renders a keyboard shortcut as one or more badge-style hints. The chip uses
+ * `currentColor` by default so it adapts to the foreground of whatever control
+ * it is rendered inside (button label, input text, etc.).
+ */
+export const ReqoreKeyboardShortcut = memo(
+  ({
+    shortcut,
+    size = 'normal',
+    oneLessSize = true,
+    color,
+    compact,
+    wrap,
+    className,
+  }: IReqoreKeyboardShortcutProps) => {
+    const labels = useMemo(() => formatShortcut(shortcut), [shortcut]);
+
+    if (!labels.length) {
+      return null;
+    }
+
+    const tagSize = oneLessSize ? getOneLessSize(size) : size;
+
+    return (
+      <StyledShortcutGroup
+        _size={tagSize}
+        wrap={wrap}
+        className={`reqore-keyboard-shortcut ${className || ''}`}
+      >
+        {labels.map((label, index) => (
+          <StyledShortcutKey
+            key={index}
+            _size={tagSize}
+            compact={compact}
+            color={color}
+            className='reqore-keyboard-shortcut-key'
+          >
+            {label}
+          </StyledShortcutKey>
+        ))}
+      </StyledShortcutGroup>
+    );
+  }
+);
+
+export default ReqoreKeyboardShortcut;

--- a/src/components/StackedBar/index.tsx
+++ b/src/components/StackedBar/index.tsx
@@ -1,0 +1,374 @@
+import { rgba } from 'polished';
+import { forwardRef, memo, useMemo } from 'react';
+import styled, { css } from 'styled-components';
+import { RADIUS_FROM_SIZE, TSizes } from '../../constants/sizes';
+import { IReqoreTheme, TReqoreIntent } from '../../constants/theme';
+import { getColorFromMaybeString, getReadableColor } from '../../helpers/colors';
+import { useReqoreTheme } from '../../hooks/useTheme';
+import { DisabledElement, RaisedElement } from '../../styles';
+import {
+  IReqoreDisabled,
+  IReqoreIntent,
+  IWithReqoreCustomTheme,
+  IWithReqoreEffect,
+  IWithReqoreFlat,
+  IWithReqoreFluid,
+  IWithReqoreSize,
+  IWithReqoreTooltip,
+  TReqoreTooltipProp,
+} from '../../types/global';
+import { StyledEffect, TReqoreEffectColor } from '../Effect';
+import { ReqoreTooltipComponent } from '../TooltipComponent';
+
+/**
+ * Height scale tuned for a stacked bar — comfortably taller than the thin
+ * `PROGRESS_HEIGHT` scale so the bar reads as a substantial element and
+ * inline value labels are never clipped. A bar with `showValues` clamps to
+ * at least {@link MIN_LABEL_HEIGHT}px.
+ */
+const STACKED_BAR_HEIGHT_FROM_SIZE: Record<TSizes, number> = {
+  micro: 10,
+  tiny: 14,
+  small: 18,
+  normal: 24,
+  big: 32,
+  huge: 40,
+  massive: 52,
+};
+
+/** Min height when only the value is shown. */
+const MIN_VALUE_HEIGHT = 18;
+/** Min height when the label is stacked under the value (two lines). */
+const MIN_VALUE_AND_LABEL_HEIGHT = 34;
+
+export interface IReqoreStackedBarItem {
+  /** Magnitude of this segment. Segments with `value <= 0` are skipped. */
+  value: number;
+  /**
+   * Segment colour. Accepts the same flexible forms as the rest of Reqore:
+   * an intent name (`'success'`), a hex colour (`'#57801a'`), or a shaded
+   * form (`'danger:lighten:2'`). When omitted, falls back to `intent`, then
+   * to a readable default.
+   */
+  color?: TReqoreEffectColor;
+  /** Shorthand intent — used as the colour when `color` is not provided. */
+  intent?: TReqoreIntent;
+  /** Human label for the segment, used in the default tooltip. */
+  label?: string;
+  /**
+   * Tooltip shown on hover. Defaults to `"<label>: <value>"` (or just the
+   * value when there is no label).
+   */
+  tooltip?: TReqoreTooltipProp;
+  /** Click handler. When set, the segment becomes interactive (pointer cursor + button role). */
+  onClick?: () => void;
+  /** Stable key for the segment. Falls back to the index when omitted. */
+  id?: string;
+}
+
+export interface IReqoreStackedBarProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>,
+    IReqoreDisabled,
+    IReqoreIntent,
+    IWithReqoreCustomTheme,
+    IWithReqoreEffect,
+    IWithReqoreFluid,
+    IWithReqoreFlat,
+    IWithReqoreSize,
+    IWithReqoreTooltip {
+  /** Ordered segments rendered left-to-right as one continuous bar. */
+  items: IReqoreStackedBarItem[];
+  /**
+   * Total to normalise segment widths against. Defaults to the sum of all
+   * item values. When larger than the sum, the remainder renders as empty
+   * track — useful for "X of Y" style bars.
+   */
+  total?: number;
+  /** Rounded (pill) ends. Defaults to `true`. */
+  rounded?: boolean;
+  /** Transparent (rather than tinted) empty track. Defaults to `false`. */
+  transparent?: boolean;
+  /** Subtle 3D "raised" treatment (inset top highlight + bottom shadow). */
+  raised?: boolean;
+  /** Explicit track height in px. Overrides the size-derived height. */
+  height?: number;
+  /**
+   * Minimum width, in percent, for any non-zero segment so a tiny count
+   * stays visible and clickable. Defaults to `2`.
+   */
+  minSegmentPercent?: number;
+  /** Render each segment's value centred inside it when it fits. Defaults to `false`. */
+  showValues?: boolean;
+  /**
+   * Render each segment's `label` stacked beneath the value, in a smaller
+   * uppercase, letter-spaced style. Implies a taller bar so both lines fit.
+   * Defaults to `false`.
+   */
+  showLabels?: boolean;
+  /**
+   * Only print a segment's value/label when it occupies at least this percent
+   * of the bar, so narrow segments don't show a cramped/clipped number.
+   * Defaults to `8`.
+   */
+  valueLabelMinPercent?: number;
+  /** Content shown when there is nothing to plot (total resolves to 0). Defaults to the empty track. */
+  emptyContent?: React.ReactNode;
+}
+
+interface IStyledTrackProps {
+  theme: IReqoreTheme;
+  $height: number;
+  $radius: number;
+  $rounded?: boolean;
+  $transparent?: boolean;
+  $flat?: boolean;
+  $fluid?: boolean;
+  $raised?: boolean;
+  $disabled?: boolean;
+}
+
+// Extends `StyledEffect` so the standard `effect` prop (gradients, glow,
+// filters, …) works exactly as it does on every other Reqore surface.
+const StyledStackedBarTrack = styled(StyledEffect)<IStyledTrackProps>`
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  overflow: hidden;
+  width: ${({ $fluid }) => ($fluid ? '100%' : '200px')};
+  height: ${({ $height }) => $height}px;
+  border-radius: ${({ $radius, $rounded }) => ($rounded === false ? 0 : `${$radius}px`)};
+  background-color: ${({ theme, $transparent }) =>
+    $transparent
+      ? 'transparent'
+      : rgba(getReadableColor(theme, undefined, undefined, true), 0.1)};
+  border: ${({ $flat, theme }) =>
+    $flat === false
+      ? `1px solid ${rgba(getReadableColor(theme, undefined, undefined, true), 0.4)}`
+      : 'none'};
+
+  ${({ $raised }) => $raised && RaisedElement}
+  ${({ $disabled }) => $disabled && DisabledElement}
+`;
+
+interface IStyledSegmentProps {
+  $color: string;
+  $percent: number;
+  $interactive: boolean;
+}
+
+const StyledStackedBarSegment = styled.div<IStyledSegmentProps>`
+  height: 100%;
+  width: ${({ $percent }) => $percent}%;
+  min-width: 0;
+  background-color: ${({ $color }) => $color};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  padding: 0 5px;
+  overflow: hidden;
+  color: #ffffff;
+  line-height: 1;
+  text-shadow: 0 1px 1px ${rgba('#000000', 0.35)};
+  white-space: nowrap;
+  transition: width 0.3s ease-out, filter 0.15s ease-out;
+  cursor: ${({ $interactive }) => ($interactive ? 'pointer' : 'default')};
+
+  &:hover {
+    ${({ $interactive }) =>
+      $interactive &&
+      css`
+        filter: brightness(1.1);
+      `}
+  }
+`;
+
+const StyledSegmentValue = styled.span`
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+`;
+
+const StyledSegmentLabel = styled.span`
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  opacity: 0.82;
+`;
+
+interface IResolvedSegment {
+  key: string;
+  color: string;
+  percent: number;
+  value: number;
+  label?: string;
+  tooltip?: TReqoreTooltipProp;
+  onClick?: () => void;
+  showValue: boolean;
+  showLabel: boolean;
+}
+
+/**
+ * A horizontal bar split into proportional, individually-coloured segments —
+ * the multi-value counterpart to `ReqoreProgress`. Each segment can carry its
+ * own intent/colour, label, tooltip, and click handler, so a single bar can
+ * summarise a breakdown (status counts, a budget split, …) and let the user
+ * drill into any slice. Segments with a non-positive value are dropped.
+ *
+ * Supports the standard Reqore surface props: `fluid`, `flat` (border),
+ * `rounded`, `raised`, `transparent`, `intent`, `customTheme`, `effect`,
+ * `size`, `disabled`, and a bar-level `tooltip`.
+ */
+const ReqoreStackedBar = memo(
+  forwardRef<HTMLDivElement, IReqoreStackedBarProps>(
+    (
+      {
+        items,
+        total,
+        size = 'normal',
+        intent,
+        customTheme,
+        inheritCustomTheme,
+        effect,
+        fluid = false,
+        rounded = true,
+        transparent = false,
+        flat = true,
+        raised = false,
+        height,
+        disabled,
+        minSegmentPercent = 2,
+        showValues = false,
+        showLabels = false,
+        valueLabelMinPercent = 8,
+        emptyContent,
+        className,
+        tooltip,
+        ...rest
+      },
+      ref
+    ) => {
+      const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
+
+      const resolvedHeight = useMemo(() => {
+        const base = height ?? STACKED_BAR_HEIGHT_FROM_SIZE[size];
+        if (showLabels) return Math.max(base, MIN_VALUE_AND_LABEL_HEIGHT);
+        if (showValues) return Math.max(base, MIN_VALUE_HEIGHT);
+        return base;
+      }, [height, size, showValues, showLabels]);
+
+      const trackRadius = rounded === false ? 0 : RADIUS_FROM_SIZE[size];
+
+      const positiveItems = useMemo(() => items.filter((item) => item.value > 0), [items]);
+
+      const sum = useMemo(
+        () => positiveItems.reduce((acc, item) => acc + item.value, 0),
+        [positiveItems]
+      );
+
+      const resolvedTotal = useMemo(() => {
+        const candidate = total ?? sum;
+        return candidate > 0 ? candidate : 0;
+      }, [total, sum]);
+
+      const segments = useMemo<IResolvedSegment[]>(() => {
+        if (resolvedTotal <= 0) return [];
+        return positiveItems.map((item, index) => {
+          const rawPercent = (item.value / resolvedTotal) * 100;
+          const percent = rawPercent > 0 ? Math.max(rawPercent, minSegmentPercent) : 0;
+          const color =
+            getColorFromMaybeString(theme, item.color || (item.intent as TReqoreEffectColor)) ||
+            getReadableColor(theme, undefined, undefined, true);
+          const tooltipContent: TReqoreTooltipProp | undefined =
+            item.tooltip ??
+            (item.label !== undefined ? `${item.label}: ${item.value}` : `${item.value}`);
+          const fits = rawPercent >= valueLabelMinPercent;
+          return {
+            key: item.id ?? `${item.label ?? 'segment'}-${index}`,
+            color,
+            percent,
+            value: item.value,
+            label: item.label,
+            tooltip: tooltipContent,
+            onClick: item.onClick,
+            showValue: showValues && fits,
+            showLabel: showLabels && item.label !== undefined && fits,
+          };
+        });
+      }, [
+        positiveItems,
+        resolvedTotal,
+        minSegmentPercent,
+        theme,
+        showValues,
+        showLabels,
+        valueLabelMinPercent,
+      ]);
+
+      return (
+        <ReqoreTooltipComponent
+          {...rest}
+          Component={StyledStackedBarTrack}
+          tooltip={tooltip}
+          ref={ref}
+          as='div'
+          theme={theme}
+          effect={effect}
+          $height={resolvedHeight}
+          $radius={trackRadius}
+          $rounded={rounded}
+          $transparent={transparent}
+          $flat={flat}
+          $fluid={fluid}
+          $raised={raised}
+          $disabled={disabled}
+          className={`${className || ''} reqore-stacked-bar`}
+          role='img'
+        >
+          {segments.length === 0
+            ? emptyContent ?? null
+            : segments.map((segment) => (
+                <ReqoreTooltipComponent
+                  key={segment.key}
+                  Component={StyledStackedBarSegment}
+                  tooltip={segment.tooltip}
+                  $color={segment.color}
+                  $percent={segment.percent}
+                  $interactive={!!segment.onClick}
+                  onClick={segment.onClick}
+                  className='reqore-stacked-bar-segment'
+                  role={segment.onClick ? 'button' : undefined}
+                  tabIndex={segment.onClick ? 0 : undefined}
+                  onKeyDown={
+                    segment.onClick
+                      ? (event: React.KeyboardEvent) => {
+                          if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault();
+                            segment.onClick?.();
+                          }
+                        }
+                      : undefined
+                  }
+                >
+                  {segment.showValue ? <StyledSegmentValue>{segment.value}</StyledSegmentValue> : null}
+                  {segment.showLabel ? (
+                    <StyledSegmentLabel>{segment.label}</StyledSegmentLabel>
+                  ) : null}
+                </ReqoreTooltipComponent>
+              ))}
+        </ReqoreTooltipComponent>
+      );
+    }
+  )
+);
+
+export default ReqoreStackedBar;

--- a/src/components/Textarea/index.tsx
+++ b/src/components/Textarea/index.tsx
@@ -14,6 +14,7 @@ import { IReqoreTheme } from '../../constants/theme';
 import { changeLightness, getReadableColor } from '../../helpers/colors';
 import { IReqoreAutoFocusRules, useAutoFocus } from '../../hooks/useAutoFocus';
 import { useCombinedRefs } from '../../hooks/useCombinedRefs';
+import { useReqoreProperty } from '../../hooks/useReqoreContext';
 import useAutosizeTextArea from '../../hooks/useTextareaAutoSize';
 import { DisabledElement, ReadOnlyElement } from '../../styles';
 import {
@@ -28,6 +29,7 @@ import { IReqoreDropdownProps } from '../Dropdown';
 import { StyledEffect } from '../Effect';
 import { IReqoreInputStyle } from '../Input';
 import ReqoreInputClearButton from '../InputClearButton';
+import { ReqoreKeyboardShortcut } from '../KeyboardShortcut';
 import { IPopoverControls } from '../Popover';
 import { ReqoreTooltipComponent } from '../TooltipComponent';
 
@@ -63,6 +65,11 @@ export interface IReqoreTextareaProps
   onClearClick?: () => any;
   wrapperStyle?: React.CSSProperties;
   focusRules?: IReqoreAutoFocusRules;
+  /**
+   * Whether to render a badge-style hint for the `focusRules` keyboard shortcut.
+   * Defaults to `true`, unless globally disabled via the `shortcutHints` UI option.
+   */
+  shortcutHint?: boolean;
   templates?: IReqoreFormTemplates;
   transparent?: boolean;
   as?: React.ElementType;
@@ -159,6 +166,15 @@ export const StyledTextarea = styled(StyledEffect)<IReqoreTextareaStyle>`
   }
 `;
 
+const StyledTextareaShortcutWrapper = styled.div`
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: flex;
+  align-items: center;
+  pointer-events: none;
+`;
+
 function Textarea<T>(
   {
     width,
@@ -179,6 +195,7 @@ function Textarea<T>(
     onChange,
     fixed,
     focusRules,
+    shortcutHint,
     templates,
     ...rest
   }: T & IReqoreTextareaProps,
@@ -187,6 +204,13 @@ function Textarea<T>(
   const { targetRef }: any = useCombinedRefs(ref);
   const [inputRef, setInputRef] = useState<HTMLTextAreaElement>(null);
   const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
+  const shortcutHintsEnabled = useReqoreProperty('shortcutHints');
+  const showShortcutHint =
+    !!focusRules?.shortcut &&
+    shortcutHint !== false &&
+    shortcutHintsEnabled !== false &&
+    !rest.readOnly &&
+    !rest.disabled;
   const [_value, setValue] = useState(value || '');
   const [popoverData, setPopoverData] = useState<IPopoverControls>(null);
   const uuid = useRef(nanoid());
@@ -267,6 +291,11 @@ function Textarea<T>(
           onClick={onClearClick}
           size={size}
         />
+        {showShortcutHint && (
+          <StyledTextareaShortcutWrapper>
+            <ReqoreKeyboardShortcut shortcut={focusRules.shortcut} size={size} compact />
+          </StyledTextareaShortcutWrapper>
+        )}
       </>
     );
   };

--- a/src/containers/ReqoreProvider.tsx
+++ b/src/containers/ReqoreProvider.tsx
@@ -263,6 +263,7 @@ const ReqoreProvider: React.FC<IReqoreNotifications> = memo(({ children, options
       customPortalId: options?.customPortalId,
       uiScale: options?.uiScale,
       glowingIcons: options?.glowingIcons ?? false,
+      shortcutHints: options?.shortcutHints ?? true,
       errorBoundaryOptions: options?.errorBoundaryOptions || DEFAULT_ERROR_BOUNDARY_OPTIONS,
     }),
     [options]
@@ -286,6 +287,7 @@ const ReqoreProvider: React.FC<IReqoreNotifications> = memo(({ children, options
         animations: resolvedOptions.animations,
         tooltips: resolvedOptions.tooltips,
         glowingIcons: resolvedOptions.glowingIcons,
+        shortcutHints: resolvedOptions.shortcutHints,
         closePopoversOnEscPress: resolvedOptions.closePopoversOnEscPress,
         // ESC Closable modals management
         closeModalsOnEscPress: resolvedOptions.closeModalsOnEscPress,

--- a/src/containers/UIProvider.tsx
+++ b/src/containers/UIProvider.tsx
@@ -21,6 +21,7 @@ export interface IReqoreOptions
     | 'customPortalId'
     | 'errorBoundaryOptions'
     | 'glowingIcons'
+    | 'shortcutHints'
   > {
   withSidebar?: boolean;
   uiScale?: number;

--- a/src/context/ReqoreContext.tsx
+++ b/src/context/ReqoreContext.tsx
@@ -45,6 +45,14 @@ export interface IReqoreContext {
    * @default false
    */
   readonly glowingIcons?: boolean;
+  /**
+   * When `true` (the default), buttons and inputs that declare a keyboard
+   * `shortcut` / `focusRules` shortcut render a badge-style hint. Set to `false`
+   * to hide all shortcut hints app-wide. Individual controls can still opt out
+   * with `shortcutHint={false}`.
+   * @default true
+   */
+  readonly shortcutHints?: boolean;
   readonly customPortalId?: string;
   readonly closePopoversOnEscPress?: boolean;
   readonly closeModalsOnEscPress?: boolean;
@@ -73,6 +81,7 @@ export default createContext<IReqoreContext>({
   },
   closePopoversOnEscPress: true,
   closeModalsOnEscPress: true,
+  shortcutHints: true,
   escClosableModals: [],
   addEscClosableModal: null,
   removeEscClosableModal: null,

--- a/src/helpers/shortcuts.ts
+++ b/src/helpers/shortcuts.ts
@@ -1,0 +1,158 @@
+/**
+ * Helpers for parsing and displaying keyboard shortcuts.
+ *
+ * Shortcuts follow the `react-hotkeys-hook` syntax: keys joined with `+`
+ * (e.g. `'mod+k'`, `'ctrl+shift+s'`) and multiple alternatives separated by a
+ * comma or passed as an array. The special `mod` key resolves to `⌘` on macOS
+ * and `Ctrl` everywhere else, so a single declaration works cross-platform.
+ */
+
+export type TReqoreKeyboardShortcut = string | string[];
+
+const MODIFIER_KEYS = [
+  'mod',
+  'meta',
+  'cmd',
+  'command',
+  'ctrl',
+  'control',
+  'alt',
+  'option',
+  'shift',
+];
+
+const KEY_SYMBOLS_MAC: Record<string, string> = {
+  mod: '⌘',
+  meta: '⌘',
+  cmd: '⌘',
+  command: '⌘',
+  ctrl: '⌃',
+  control: '⌃',
+  alt: '⌥',
+  option: '⌥',
+  shift: '⇧',
+  enter: '↵',
+  return: '↵',
+  esc: 'Esc',
+  escape: 'Esc',
+  backspace: '⌫',
+  delete: '⌦',
+  del: '⌦',
+  tab: '⇥',
+  space: 'Space',
+  up: '↑',
+  arrowup: '↑',
+  down: '↓',
+  arrowdown: '↓',
+  left: '←',
+  arrowleft: '←',
+  right: '→',
+  arrowright: '→',
+};
+
+const KEY_LABELS: Record<string, string> = {
+  mod: 'Ctrl',
+  meta: 'Meta',
+  cmd: 'Win',
+  command: 'Win',
+  ctrl: 'Ctrl',
+  control: 'Ctrl',
+  alt: 'Alt',
+  option: 'Alt',
+  shift: 'Shift',
+  enter: 'Enter',
+  return: 'Enter',
+  esc: 'Esc',
+  escape: 'Esc',
+  backspace: 'Backspace',
+  delete: 'Del',
+  del: 'Del',
+  tab: 'Tab',
+  space: 'Space',
+  up: '↑',
+  arrowup: '↑',
+  down: '↓',
+  arrowdown: '↓',
+  left: '←',
+  arrowleft: '←',
+  right: '→',
+  arrowright: '→',
+};
+
+/**
+ * Detect macOS so we can render the platform-appropriate modifier glyphs.
+ *
+ * This intentionally mirrors `react-hotkeys-hook`'s own Apple detection
+ * (`/mac/i.test(navigator.userAgent)` excluding iOS) so the displayed hint
+ * always matches the modifier the library actually listens for — using a
+ * different source (e.g. `navigator.platform`) could make the hint say `⌘`
+ * while the binding expects `Ctrl`, or vice versa.
+ */
+export const isMacOS = (): boolean => {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  const ua = navigator.userAgent;
+
+  return /mac/i.test(ua) && !/iphone|ipad|ipod/i.test(ua);
+};
+
+const formatToken = (token: string, mac: boolean): string => {
+  const key = token.trim().toLowerCase();
+
+  // The `focusRules` shortcut on inputs supports these aliases that match any
+  // letter / number key — render a readable range instead of the literal word.
+  if (key === 'letters') {
+    return 'A-Z';
+  }
+  if (key === 'numbers') {
+    return '0-9';
+  }
+
+  const map = mac ? KEY_SYMBOLS_MAC : KEY_LABELS;
+
+  if (map[key]) {
+    return map[key];
+  }
+
+  if (key.length === 1) {
+    return key.toUpperCase();
+  }
+
+  return key.charAt(0).toUpperCase() + key.slice(1);
+};
+
+const splitShortcut = (shortcut: TReqoreKeyboardShortcut): string[] =>
+  (Array.isArray(shortcut) ? shortcut : [shortcut])
+    .flatMap((combo) => (typeof combo === 'string' ? combo.split(',') : []))
+    .map((combo) => combo.trim())
+    .filter(Boolean);
+
+/**
+ * Turn a single combo (e.g. `'mod+shift+k'`) into a display string.
+ * macOS concatenates glyphs (`⌘⇧K`), other platforms join with `+` (`Ctrl+Shift+K`).
+ */
+export const formatShortcutCombo = (combo: string, mac: boolean = isMacOS()): string =>
+  combo
+    .split('+')
+    .map((token) => formatToken(token, mac))
+    .join(mac ? '' : '+');
+
+/**
+ * Format a shortcut declaration into one display string per alternative combo.
+ */
+export const formatShortcut = (
+  shortcut: TReqoreKeyboardShortcut,
+  mac: boolean = isMacOS()
+): string[] => splitShortcut(shortcut).map((combo) => formatShortcutCombo(combo, mac));
+
+/**
+ * Whether any combo in the shortcut uses a modifier key. Used to decide if a
+ * button shortcut should still fire while a form field is focused (combos with a
+ * modifier are safe; bare single keys would clash with typing).
+ */
+export const shortcutHasModifier = (shortcut: TReqoreKeyboardShortcut): boolean =>
+  splitShortcut(shortcut).some((combo) =>
+    combo.split('+').some((token) => MODIFIER_KEYS.includes(token.trim().toLowerCase()))
+  );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,11 +23,15 @@ export {
   ReqoreDataView,
   reqoreDataValueIntent,
   reqoreDataValueKind,
+  reqoreCoerceValueToKind,
+  reqoreDeleteAtPath,
   reqoreEnvelopeType,
   reqoreFormatScalar,
   reqoreHasStructuredValue,
   reqoreIsEnvelope,
   reqoreIsRecord,
+  reqoreRenameKeyAtPath,
+  reqoreSetAtPath,
   reqoreUnwrapEnvelope,
 } from './components/DataView';
 export * from './components/DatePicker';
@@ -99,6 +103,7 @@ export { ReqoreSlider } from './components/Slider';
 export { ReqoreHorizontalSpacer, ReqoreSpacer, ReqoreVerticalSpacer } from './components/Spacer';
 export { ReqoreSpan } from './components/Span';
 export { ReqoreSpinner } from './components/Spinner';
+export { default as ReqoreStackedBar } from './components/StackedBar';
 export { default as ReqoreStatistic } from './components/Statistic';
 export { default as ReqoreTable } from './components/Table';
 export { ReqoreTableBodyCell } from './components/Table/cell';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,6 +54,18 @@ export {
 export { default as ReqoreIcon } from './components/Icon';
 export { ReqoreIconPicker } from './components/IconPicker';
 export { default as ReqoreInput } from './components/Input';
+export {
+  default as ReqoreKeyboardShortcut,
+  ReqoreKeyboardShortcut as ReqoreKeyboardShortcutComponent,
+} from './components/KeyboardShortcut';
+export type { IReqoreKeyboardShortcutProps } from './components/KeyboardShortcut';
+export {
+  formatShortcut,
+  formatShortcutCombo,
+  isMacOS,
+  shortcutHasModifier,
+} from './helpers/shortcuts';
+export type { TReqoreKeyboardShortcut } from './helpers/shortcuts';
 export { ReqoreKeyValueTable } from './components/KeyValueTable';
 export * from './components/Label';
 export { default as ReqoreLayoutContent } from './components/Layout/content';

--- a/src/stories/Button/Button.stories.tsx
+++ b/src/stories/Button/Button.stories.tsx
@@ -1,7 +1,10 @@
 import { StoryFn, StoryObj } from '@storybook/react';
 import { noop } from 'lodash';
+import { useState } from 'react';
+import { expect, fireEvent } from 'storybook/test';
+import { _testsWaitForText } from '../../../__tests__/utils';
 import ReqoreButton from '../../components/Button';
-import { ReqoreControlGroup } from '../../index';
+import { ReqoreControlGroup, ReqoreMessage, ReqoreVerticalSpacer } from '../../index';
 import { StoryMeta } from '../utils';
 import { ALL_SIZES, IconArg, RadiusSizeArg, SizeArg } from '../utils/args';
 
@@ -554,6 +557,52 @@ export const RadiusSize: Story = {
       ))}
     </ReqoreControlGroup>
   ),
+};
+
+export const Shortcut: Story = {
+  render: () => {
+    const [count, setCount] = useState(0);
+
+    return (
+      <ReqoreControlGroup vertical>
+        <ReqoreMessage intent='info'>Pressed {count} time(s)</ReqoreMessage>
+        <ReqoreVerticalSpacer height={10} />
+        <ReqoreControlGroup wrap>
+          <ReqoreButton
+            icon='SearchLine'
+            shortcut='mod+k'
+            badge={3}
+            onClick={() => setCount((c) => c + 1)}
+            className='shortcut-button'
+          >
+            Search
+          </ReqoreButton>
+          <ReqoreButton icon='Save3Line' shortcut='mod+s' intent='success'>
+            Save
+          </ReqoreButton>
+          <ReqoreButton icon='DeleteBinLine' shortcut='mod+shift+backspace' intent='danger'>
+            Delete
+          </ReqoreButton>
+          <ReqoreButton icon='SettingsLine' shortcut='mod+,' shortcutHint={false}>
+            Settings (hidden hint)
+          </ReqoreButton>
+        </ReqoreControlGroup>
+      </ReqoreControlGroup>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    // The hint badge renders next to the button label
+    await expect(
+      canvasElement.querySelector('.shortcut-button .reqore-keyboard-shortcut')
+    ).toBeTruthy();
+
+    // `mod` is ⌘ on macOS and Ctrl elsewhere; press both so it matches on any
+    // platform (react-hotkeys-hook only checks the platform-appropriate one).
+    fireEvent.keyDown(document, { key: 'k', code: 'KeyK', metaKey: true, ctrlKey: true });
+
+    // waitFor the click handler's state update to flush before asserting
+    await _testsWaitForText('Pressed 1 time(s)');
+  },
 };
 
 export const MultipleGradients: Story = {

--- a/src/stories/DataView/DataView.stories.tsx
+++ b/src/stories/DataView/DataView.stories.tsx
@@ -1,6 +1,7 @@
-import { expect, fireEvent } from 'storybook/test';
+import { expect, fireEvent, fn } from 'storybook/test';
 import { StoryObj } from '@storybook/react';
 import { noop } from 'lodash';
+import { useState } from 'react';
 import { _testsWaitForText } from '../../../__tests__/utils';
 import {
   IReqoreDataViewProps,
@@ -350,5 +351,333 @@ export const InteractionToggle: Story = {
     if (summary) fireEvent.click(summary);
     await _testsWaitForText('workflow_instanceid');
     await expect(canvasElement.querySelectorAll('.reqore-data-view-row').length).toBeGreaterThan(0);
+  },
+};
+
+/* ===========================================================
+ * Editable mode — click-to-edit JSON Schema builder primitives
+ * ===========================================================
+ *
+ * Every editable story below uses a tiny harness so the DataView
+ * stays fully controlled: the harness keeps the latest tree in
+ * `useState`, and every commit (value edit, key rename, row
+ * delete, add property / item) lands via `onDataChange(next)` then
+ * re-enters via `data`.
+ *
+ * The UX vocabulary the stories exercise:
+ *   - **Click a value chip** → swaps to an input, focused.
+ *     **Enter / blur** commits, **Esc** reverts.
+ *   - **Click a key chip** → same shape, but for the property name.
+ *     Duplicate keys are refused.
+ *   - **Hover a row** → reveals a danger-intent delete button on
+ *     the right.
+ *   - **Add property / Add item** lives at the bottom of every
+ *     object / array; click → expands into an inline form (key +
+ *     type picker) → submit → appends. The type picker supports
+ *     **string / number / boolean / object (hash) / array (list) /
+ *     null**.
+ *
+ *  This is the structural primitive layer. A schema-aware mode
+ *  (JSON Schema type picker per property, required toggles, enum
+ *  editor, $ref resolution) ships on top of these primitives —
+ *  see `.tasks/EDITABLE_DATAVIEW.md`.
+ */
+
+const OPENAPI_PET_SCHEMA = {
+  type: 'object',
+  description: 'A pet for sale in the pet store.',
+  required: ['id', 'name'],
+  properties: {
+    id: {
+      type: 'integer',
+      format: 'int64',
+      description: 'Unique pet identifier (read-only).',
+      example: 10,
+    },
+    name: {
+      type: 'string',
+      description: 'Pet display name.',
+      example: 'doggie',
+    },
+    category: {
+      type: 'object',
+      description: 'Owning category — referenced from /categories.',
+      properties: {
+        id: { type: 'integer', format: 'int64' },
+        name: { type: 'string', example: 'Dogs' },
+      },
+    },
+    photoUrls: {
+      type: 'array',
+      description: 'Public photo URLs.',
+      items: { type: 'string', format: 'uri' },
+    },
+    status: {
+      type: 'string',
+      description: 'Pet availability — drives the storefront filter.',
+      enum: ['available', 'pending', 'sold'],
+    },
+  },
+};
+
+const EditableHarness = (args: IReqoreDataViewProps) => {
+  const [tree, setTree] = useState<unknown>(args.data ?? {});
+  return (
+    <ReqoreDataView
+      {...args}
+      data={tree}
+      editable
+      onDataChange={(next) => {
+        setTree(next);
+        args.onDataChange?.(next);
+      }}
+    />
+  );
+};
+
+/**
+ * Realistic OpenAPI / JSON Schema fragment with nested objects, an
+ * array of strings (`photoUrls`), and an `enum` array. Demonstrates
+ * that the editor handles **complex, deeply nested shapes**, not just
+ * a flat key-value record.
+ *
+ * Try in the storybook:
+ *  - Click `pet for sale in the pet store.` to rewrite the
+ *    `description`.
+ *  - Click `doggie` to rename the pet's example.
+ *  - Hover the `name` row to expose the delete button.
+ *  - Click the `properties` key to rename it.
+ *  - Use `+ Add property` at the bottom of any object level to add a
+ *    new field. The type picker creates strings, numbers, booleans,
+ *    objects (hashes), arrays (lists), or null.
+ */
+export const EditableOpenApiSchema: Story = {
+  args: {
+    label: 'OpenAPI 3 — components.schemas.Pet',
+    icon: 'CodeLine',
+    data: OPENAPI_PET_SCHEMA,
+    defaultExpandDepth: 99,
+    collapsibleRoot: false,
+  },
+  render: (args) => <EditableHarness {...args} />,
+};
+
+/**
+ * Click-to-edit interaction — start by displaying the chip, click
+ * to switch to an input, edit, commit on Enter, observe the new
+ * value rendered as a chip again.
+ */
+export const ClickToEditScalar: Story = {
+  args: {
+    label: 'Click to edit a scalar',
+    icon: 'CursorLine',
+    data: { display_name: 'Customer', retries: 3, is_public: false },
+    defaultExpandDepth: 99,
+    collapsibleRoot: false,
+    onDataChange: fn(),
+  },
+  render: (args) => <EditableHarness {...args} />,
+  play: async ({ canvasElement, args }) => {
+    await _testsWaitForText('display_name');
+
+    const rows = Array.from(
+      canvasElement.querySelectorAll('.reqore-data-view-row')
+    );
+    const row = rows.find(
+      (r) => r.querySelector('.reqore-data-view-key')?.textContent === 'display_name'
+    )!;
+
+    // Step 1: chip is visible, no input yet.
+    await expect(
+      row.querySelector('input.reqore-data-view-edit')
+    ).toBeNull();
+    await expect(row.querySelector('.reqore-data-view-value')).toBeTruthy();
+
+    // Step 2: click the value chip → input appears.
+    const chip = row.querySelector('.reqore-data-view-value') as HTMLElement;
+    fireEvent.click(chip);
+    const input = row.querySelector(
+      'input.reqore-data-view-edit'
+    ) as HTMLInputElement;
+    await expect(input).toBeTruthy();
+
+    // Step 3: edit + commit on Enter.
+    fireEvent.change(input, { target: { value: 'Customer v2' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await expect(args.onDataChange).toHaveBeenCalled();
+    const last = (args.onDataChange as ReturnType<typeof fn>).mock.calls.at(-1)?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    await expect(last?.display_name).toBe('Customer v2');
+  },
+};
+
+/**
+ * Build a JSON schema from scratch. The tree starts as an empty
+ * object — only the `+ Add property` affordance is visible. The
+ * play function expands the form, types a key (`type`), picks the
+ * `String` type, commits, and observes the new property in the
+ * tree.
+ */
+export const BuildFromEmptyHash: Story = {
+  args: {
+    label: 'Build from {} — Add property → fill out the form',
+    icon: 'AddBoxLine',
+    data: {},
+    defaultExpandDepth: 99,
+    collapsibleRoot: false,
+    onDataChange: fn(),
+  },
+  render: (args) => <EditableHarness {...args} />,
+  play: async ({ canvasElement, args }) => {
+    await _testsWaitForText('Add property');
+
+    // Click the trailing "Add property" button → form expands.
+    const addRow = canvasElement.querySelector(
+      '.reqore-data-view-add-row'
+    ) as HTMLElement;
+    const trigger = addRow.querySelector('button') as HTMLElement;
+    fireEvent.click(trigger);
+
+    // The expanded form has a key input + a type picker + commit /
+    // cancel buttons. We type a key + submit (default type =
+    // string).
+    const keyInput = addRow.querySelector(
+      'input.reqore-data-view-add-key'
+    ) as HTMLInputElement;
+    await expect(keyInput).toBeTruthy();
+    fireEvent.change(keyInput, { target: { value: 'type' } });
+    const commit = addRow.querySelector(
+      '.reqore-data-view-add-commit'
+    ) as HTMLElement;
+    fireEvent.click(commit);
+
+    // The tree now carries `type: ''` — string defaults to empty.
+    const last = (args.onDataChange as ReturnType<typeof fn>).mock.calls.at(-1)?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    await expect(last).toEqual({ type: '' });
+  },
+};
+
+/**
+ * Array editing — start with a populated `enum`-style array, add a
+ * new item, delete an existing one. Shows the per-row delete +
+ * trailing `+ Add item` affordance.
+ */
+export const EditableArrayOps: Story = {
+  args: {
+    label: 'Array ops — pet status enum',
+    icon: 'ListUnordered',
+    data: { status_enum: ['available', 'pending', 'sold'] },
+    defaultExpandDepth: 99,
+    collapsibleRoot: false,
+    onDataChange: fn(),
+  },
+  render: (args) => <EditableHarness {...args} />,
+  play: async ({ canvasElement, args }) => {
+    await _testsWaitForText('status_enum');
+
+    // The array renders three items. In editable mode the inline
+    // chip-row shortcut is off, so each item gets its own row.
+    const arrayItems = canvasElement.querySelectorAll(
+      '.reqore-data-view-array-item'
+    );
+    await expect(arrayItems.length).toBe(3);
+
+    // Delete the second item (`pending`). Hover-reveal the action
+    // group; click the delete button.
+    const secondRow = arrayItems[1] as HTMLElement;
+    const deleteButton = secondRow.querySelector(
+      '.reqore-data-view-row-delete'
+    ) as HTMLElement;
+    await expect(deleteButton).toBeTruthy();
+    fireEvent.click(deleteButton);
+
+    const afterDelete = (args.onDataChange as ReturnType<typeof fn>).mock.calls.at(-1)?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    await expect(afterDelete?.status_enum).toEqual(['available', 'sold']);
+  },
+};
+
+/**
+ * Switch the type of a value as part of editing it. Click the value
+ * chip to enter edit mode — the control group renders as
+ * `[input] [type ▾] [✓ Save] [✗ Cancel]`. The type picker shows the
+ * value's CURRENT kind and offers all six (string / number / boolean
+ * / object (hash) / array (list) / null). Picking a new kind
+ * coerces the current DRAFT (not the original value), so a user who
+ * has just typed `42` and realises the property should be a number
+ * keeps the `42` they typed — they don't lose their work.
+ *
+ * Coercion rules:
+ *   - string → number  → parse; falls back to 0 on a non-numeric source.
+ *   - string → boolean → 'true' / '1' / 'yes' → true; else false.
+ *   - any    → object  → replaces the scalar with `{}`.
+ *   - any    → array   → replaces the scalar with `[]`.
+ *
+ * Picking `string` or `number` keeps the cell in edit mode (the
+ * input type swaps to match the new kind, draft preserved). Picking
+ * `boolean` / `object` / `array` / `null` commits + exits so the
+ * right control takes over (checkbox / structural view / "—" chip).
+ *
+ * Row actions stay purely structural — only `delete` lives in the
+ * hover-revealed group; type-change is per-edit by design.
+ */
+export const EditableTypeChange: Story = {
+  args: {
+    label: 'Switch the type of an existing row',
+    icon: 'Repeat2Line',
+    data: { retries: '5', is_public: 'true', payload: 'inline' },
+    defaultExpandDepth: 99,
+    collapsibleRoot: false,
+    onDataChange: fn(),
+  },
+  render: (args) => <EditableHarness {...args} />,
+};
+
+/**
+ * Click-to-rename a key. Demonstrates that the key tag flips to an
+ * input on click, commits on Enter, and refuses duplicate keys.
+ */
+export const EditableKeyRename: Story = {
+  args: {
+    label: 'Rename a property key in place',
+    icon: 'EditBoxLine',
+    data: { display_name: 'Customer', retries: 3 },
+    defaultExpandDepth: 99,
+    collapsibleRoot: false,
+    onDataChange: fn(),
+  },
+  render: (args) => <EditableHarness {...args} />,
+  play: async ({ canvasElement, args }) => {
+    await _testsWaitForText('display_name');
+
+    const rows = Array.from(
+      canvasElement.querySelectorAll('.reqore-data-view-row')
+    );
+    const row = rows.find(
+      (r) => r.querySelector('.reqore-data-view-key')?.textContent === 'display_name'
+    )!;
+
+    // Click key chip → input appears.
+    const keyChip = row.querySelector('.reqore-data-view-key') as HTMLElement;
+    fireEvent.click(keyChip);
+    const keyInput = row.querySelector(
+      'input.reqore-data-view-key-edit'
+    ) as HTMLInputElement;
+    await expect(keyInput).toBeTruthy();
+
+    // Rename + Enter commits.
+    fireEvent.change(keyInput, { target: { value: 'label' } });
+    fireEvent.keyDown(keyInput, { key: 'Enter' });
+
+    const last = (args.onDataChange as ReturnType<typeof fn>).mock.calls.at(-1)?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    await expect(Object.keys(last ?? {})).toEqual(['label', 'retries']);
+    await expect(last?.label).toBe('Customer');
   },
 };

--- a/src/stories/Input/Input.stories.tsx
+++ b/src/stories/Input/Input.stories.tsx
@@ -1,5 +1,6 @@
 import { StoryFn, StoryObj } from '@storybook/react';
 import { useState } from 'react';
+import { expect } from 'storybook/test';
 import ReqoreInput, { IReqoreInputProps } from '../../components/Input';
 import { ReqoreControlGroup } from '../../index';
 import { StoryMeta } from '../utils';
@@ -261,4 +262,46 @@ export const RadiusSize: Story = {
       ))}
     </ReqoreControlGroup>
   ),
+};
+
+export const ShortcutHint: Story = {
+  render: () => {
+    const [value, setValue] = useState('Clearable value');
+
+    return (
+      <ReqoreControlGroup vertical fluid gapSize='small'>
+        <ReqoreInput
+          icon='SearchLine'
+          placeholder='Press / to focus'
+          focusRules={{ type: 'keypress', shortcut: '/', doNotInsertShortcut: true }}
+        />
+        {/* Clearable + value: the hint badge should sit to the left of the clear button */}
+        <ReqoreInput
+          value={value}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+          onClearClick={() => setValue('')}
+          placeholder='Clearable, press k to focus'
+          focusRules={{ type: 'keypress', shortcut: 'k', doNotInsertShortcut: true }}
+        />
+        {/* Clearable + value + right icon: badge sits left of both */}
+        <ReqoreInput
+          value={value}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+          onClearClick={() => setValue('')}
+          rightIcon='Calendar2Line'
+          placeholder='Clearable + right icon'
+          focusRules={{ type: 'keypress', shortcut: 'l', doNotInsertShortcut: true }}
+        />
+        <ReqoreInput
+          placeholder='Hint hidden via shortcutHint={false}'
+          shortcutHint={false}
+          focusRules={{ type: 'keypress', shortcut: 'j', doNotInsertShortcut: true }}
+        />
+      </ReqoreControlGroup>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    // Three of the four inputs render a hint (the last opts out)
+    await expect(canvasElement.querySelectorAll('.reqore-keyboard-shortcut').length).toBe(3);
+  },
 };

--- a/src/stories/KeyboardShortcut/KeyboardShortcut.stories.tsx
+++ b/src/stories/KeyboardShortcut/KeyboardShortcut.stories.tsx
@@ -1,0 +1,104 @@
+import { StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { expect, fireEvent } from 'storybook/test';
+import { _testsWaitForText } from '../../../__tests__/utils';
+import { ReqoreKeyboardShortcut } from '../../components/KeyboardShortcut';
+import {
+  ReqoreButton,
+  ReqoreControlGroup,
+  ReqoreInput,
+  ReqoreMessage,
+  ReqoreTextarea,
+  ReqoreVerticalSpacer,
+} from '../../index';
+import { StoryMeta } from '../utils';
+import { SizeArg } from '../utils/args';
+
+const meta = {
+  title: 'Utilities/KeyboardShortcut',
+  component: ReqoreKeyboardShortcut,
+  argTypes: {
+    ...SizeArg,
+  },
+  args: {
+    shortcut: 'mod+k',
+  },
+} as StoryMeta<typeof ReqoreKeyboardShortcut>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <ReqoreControlGroup vertical>
+      <ReqoreKeyboardShortcut {...args} shortcut='mod+k' />
+      <ReqoreKeyboardShortcut {...args} shortcut='ctrl+shift+s' />
+      <ReqoreKeyboardShortcut {...args} shortcut={['mod+k', 'ctrl+j']} />
+      <ReqoreKeyboardShortcut {...args} shortcut='shift+/' />
+      <ReqoreKeyboardShortcut {...args} shortcut='escape' />
+    </ReqoreControlGroup>
+  ),
+};
+
+export const OnButtons: Story = {
+  render: () => {
+    const [count, setCount] = useState(0);
+
+    return (
+      <ReqoreControlGroup vertical>
+        <ReqoreMessage intent='info'>Pressed {count} time(s)</ReqoreMessage>
+        <ReqoreVerticalSpacer height={10} />
+        <ReqoreControlGroup wrap>
+          <ReqoreButton
+            icon='SearchLine'
+            shortcut='mod+k'
+            onClick={() => setCount((c) => c + 1)}
+            className='shortcut-button'
+          >
+            Search
+          </ReqoreButton>
+          <ReqoreButton icon='Save3Line' shortcut='mod+s' intent='success'>
+            Save
+          </ReqoreButton>
+          <ReqoreButton icon='DeleteBinLine' shortcut='mod+shift+backspace' intent='danger'>
+            Delete
+          </ReqoreButton>
+          <ReqoreButton icon='SettingsLine' shortcut='mod+,' shortcutHint={false}>
+            Settings (hidden hint)
+          </ReqoreButton>
+        </ReqoreControlGroup>
+      </ReqoreControlGroup>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    // The hint badge renders next to the button label
+    await expect(
+      canvasElement.querySelector('.shortcut-button .reqore-keyboard-shortcut')
+    ).toBeTruthy();
+
+    // `mod` is ⌘ on macOS and Ctrl elsewhere; press both so it matches on any
+    // platform (react-hotkeys-hook only checks the platform-appropriate one).
+    fireEvent.keyDown(document, { key: 'k', code: 'KeyK', metaKey: true, ctrlKey: true });
+
+    // waitFor the click handler's state update to flush before asserting
+    await _testsWaitForText('Pressed 1 time(s)');
+  },
+};
+
+export const OnInputs: Story = {
+  render: () => (
+    <ReqoreControlGroup vertical fluid>
+      <ReqoreInput
+        placeholder='Press / to focus'
+        focusRules={{ type: 'keypress', shortcut: '/', doNotInsertShortcut: true }}
+      />
+      <ReqoreTextarea
+        placeholder='Press k to focus'
+        focusRules={{ type: 'keypress', shortcut: 'k', doNotInsertShortcut: true }}
+      />
+    </ReqoreControlGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelectorAll('.reqore-keyboard-shortcut').length).toBe(2);
+  },
+};

--- a/src/stories/Popover/Popover.stories.tsx
+++ b/src/stories/Popover/Popover.stories.tsx
@@ -647,6 +647,11 @@ export const InCustomPortal: Story = {
 };
 
 export const KeepOpenOnHoverWithClickableContent: Story = {
+  parameters: {
+    chromatic: {
+      disable: true,
+    },
+  },
   render: () => {
     const [clickedButton, setClickedButton] = useState<string | null>(null);
 

--- a/src/stories/StackedBar/StackedBar.stories.tsx
+++ b/src/stories/StackedBar/StackedBar.stories.tsx
@@ -1,0 +1,220 @@
+import { StoryFn, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import ReqoreStackedBar, {
+  IReqoreStackedBarItem,
+  IReqoreStackedBarProps,
+} from '../../components/StackedBar';
+import { ReqoreControlGroup } from '../../index';
+import { StoryMeta } from '../utils';
+
+const meta = {
+  title: 'Utilities/StackedBar',
+  component: ReqoreStackedBar,
+} as StoryMeta<typeof ReqoreStackedBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const STATUS_ITEMS: IReqoreStackedBarItem[] = [
+  { id: 'complete', label: 'Complete', value: 124, intent: 'success' },
+  { id: 'error', label: 'Error', value: 18, intent: 'danger' },
+  { id: 'in-progress', label: 'In-progress', value: 32, intent: 'info' },
+  { id: 'waiting', label: 'Waiting', value: 9, intent: 'warning' },
+];
+
+const Template: StoryFn<IReqoreStackedBarProps> = (args) => (
+  <ReqoreControlGroup vertical gapSize='big' style={{ width: '420px' }}>
+    <ReqoreStackedBar {...args} />
+  </ReqoreControlGroup>
+);
+
+export const Basic: Story = {
+  render: Template,
+  args: {
+    fluid: true,
+    items: STATUS_ITEMS,
+  },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <ReqoreControlGroup vertical gapSize='big' style={{ width: '420px' }}>
+      <ReqoreStackedBar {...args} size='tiny' />
+      <ReqoreStackedBar {...args} size='small' />
+      <ReqoreStackedBar {...args} size='normal' />
+      <ReqoreStackedBar {...args} size='big' />
+      <ReqoreStackedBar {...args} size='huge' />
+    </ReqoreControlGroup>
+  ),
+  args: { fluid: true, items: STATUS_ITEMS },
+};
+
+export const WithValues: Story = {
+  render: Template,
+  args: { fluid: true, showValues: true, items: STATUS_ITEMS },
+};
+
+/** `showLabels` stacks each segment's label under its value, in a smaller
+ *  uppercase, letter-spaced style — the bar grows taller to fit both lines. */
+export const WithLabels: Story = {
+  render: Template,
+  args: { fluid: true, showValues: true, showLabels: true, items: STATUS_ITEMS },
+};
+
+/** `flat={false}` draws a border around the track. */
+export const WithBorder: Story = {
+  render: Template,
+  args: { fluid: true, flat: false, showValues: true, items: STATUS_ITEMS },
+};
+
+/** `raised` adds the subtle inset 3D treatment (top highlight + bottom
+ *  shadow) shared with Panel, Bubble, and friends. */
+export const Raised: Story = {
+  render: Template,
+  args: { fluid: true, raised: true, showValues: true, items: STATUS_ITEMS },
+};
+
+/** The standard `effect` prop works as it does on every Reqore surface —
+ *  here a glow. */
+export const WithGlow: Story = {
+  render: Template,
+  args: {
+    fluid: true,
+    showValues: true,
+    effect: { glow: { color: 'info', size: 2 } },
+    items: STATUS_ITEMS,
+  },
+};
+
+/** `effect.gradient` fills the track itself, so it shows behind the
+ *  *unfilled* remainder — give the bar a `total` well above the sum and
+ *  the gradient reads clearly to the right of the segments. */
+export const WithGradient: Story = {
+  render: Template,
+  args: {
+    fluid: true,
+    // sum is 183; a 420 total leaves well over half the track empty.
+    total: 420,
+    effect: { gradient: { colors: { 0: 'info', 100: 'success' }, direction: 'to right' } },
+    items: STATUS_ITEMS,
+  },
+};
+
+/** `transparent` drops the tinted empty track. */
+export const Transparent: Story = {
+  render: Template,
+  args: { fluid: true, transparent: true, total: 220, showValues: true, items: STATUS_ITEMS },
+};
+
+/** `rounded={false}` squares the corners. */
+export const NotRounded: Story = {
+  render: Template,
+  args: { fluid: true, rounded: false, showValues: true, items: STATUS_ITEMS },
+};
+
+/** `disabled` dims the bar and blocks interaction. */
+export const Disabled: Story = {
+  render: Template,
+  args: { fluid: true, disabled: true, showValues: true, items: STATUS_ITEMS },
+};
+
+/** A bar-level `tooltip` (in addition to the per-segment tooltips). */
+export const WithTooltip: Story = {
+  render: Template,
+  args: {
+    fluid: true,
+    showValues: true,
+    tooltip: { content: '183 orders in the last 24h', openOnMount: true, placement: 'top' },
+    items: STATUS_ITEMS,
+  },
+  play: async () => {
+    userEvent.hover(document.querySelector('.reqore-stacked-bar')!);
+  },
+};
+
+/** Non-fluid bars fall back to the default fixed width. */
+export const FixedWidth: Story = {
+  render: (args) => <ReqoreStackedBar {...args} />,
+  args: { showValues: true, items: STATUS_ITEMS },
+};
+
+export const CustomColors: Story = {
+  render: Template,
+  args: {
+    fluid: true,
+    items: [
+      { label: 'A', value: 3, color: '#57801a' },
+      { label: 'B', value: 5, color: '#81358a' },
+      { label: 'C', value: 2, color: 'danger:lighten:2' },
+    ],
+  },
+};
+
+export const PartialOfTotal: Story = {
+  render: Template,
+  args: {
+    fluid: true,
+    // total exceeds the sum (10), so 50% of the track stays empty
+    total: 20,
+    items: [
+      { label: 'Done', value: 7, intent: 'success' },
+      { label: 'Failed', value: 3, intent: 'danger' },
+    ],
+  },
+};
+
+export const Empty: Story = {
+  render: Template,
+  args: {
+    fluid: true,
+    items: [
+      { label: 'Complete', value: 0, intent: 'success' },
+      { label: 'Error', value: 0, intent: 'danger' },
+    ],
+  },
+};
+
+/** Tiny values still render at the minimum segment width so they stay
+ *  visible and clickable. */
+export const TinySegmentsStayVisible: Story = {
+  render: Template,
+  args: {
+    fluid: true,
+    minSegmentPercent: 4,
+    items: [
+      { label: 'Complete', value: 9990, intent: 'success' },
+      { label: 'Error', value: 1, intent: 'danger' },
+    ],
+  },
+};
+
+/** Each segment is clickable; the play test confirms a segment click
+ *  fires the handler and that zero-value statuses are not rendered. */
+export const ClickableSegments: Story = {
+  render: (args) => (
+    <ReqoreControlGroup vertical gapSize='big' style={{ width: '420px' }}>
+      <ReqoreStackedBar {...args} />
+    </ReqoreControlGroup>
+  ),
+  args: {
+    fluid: true,
+    items: [
+      { id: 'complete', label: 'Complete', value: 124, intent: 'success', onClick: fn() },
+      { id: 'error', label: 'Error', value: 18, intent: 'danger', onClick: fn() },
+      { id: 'blocked', label: 'Blocked', value: 0, intent: 'muted', onClick: fn() },
+    ],
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const segments = canvasElement.querySelectorAll('.reqore-stacked-bar-segment');
+    // Two positive segments render; the zero-value "Blocked" is dropped.
+    await expect(segments.length).toBe(2);
+    await userEvent.click(segments[1]!);
+    const errorItem = (args.items as IReqoreStackedBarItem[])[1];
+    await expect(errorItem.onClick).toHaveBeenCalledTimes(1);
+    // The dropped segment's handler never fires.
+    const blockedItem = (args.items as IReqoreStackedBarItem[])[2];
+    await expect(blockedItem.onClick).not.toHaveBeenCalled();
+    void canvas;
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -12552,6 +12552,11 @@ react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
 
+react-hotkeys-hook@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-5.3.2.tgz#7715fcc43dc4be6efefe04eca22f8faa0f799567"
+  integrity sha512-DDDy9xK6mbTQ6aPlQvIl0dA/a90T/AWml4Rm21JXFDLlRHalIg4/Rv3equUQYs5xPTWq+oEl6RD7mi/nBpU3Uw==
+
 react-icons@5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.4.0.tgz#443000f6e5123ee1b21ea8c0a716f6e7797f7416"


### PR DESCRIPTION
Adds keyboard shortcut support to buttons and shortcut hints to buttons/inputs:

- Buttons gain a `shortcut` prop (react-hotkeys-hook) that triggers onClick; `mod` maps to Cmd on macOS and Ctrl elsewhere. Combos with a modifier also fire while a form field is focused; bare keys do not.
- New `ReqoreKeyboardShortcut` component renders badge-style kbd hints using `currentColor` so they adapt to any surface (intent buttons, inputs, etc.).
- Inputs/Textareas render a hint derived from their existing `focusRules` shortcut; hint is positioned left of the clear button and right icon.
- New global `shortcutHints` UI option (default true) plus per-control `shortcutHint` to opt out.
- Shortcut formatting helpers (formatShortcut, isMacOS, shortcutHasModifier).
- Stories + unit/interaction tests.