### PR TITLE
fix(table): subtract header height from filled body so the last row isn't clipped

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.70.1",
+  "version": "0.70.2",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -342,6 +342,11 @@ const ReqoreTable = ({
   }, [wrap, hasColumnWrap, virtualized]);
 
   const [isScrolled, setIsScrolled] = useState<boolean>(false);
+  // Live height of the header (column labels + the filter row when present). When
+  // the table `fill`s its container the virtualized body must leave room for this
+  // header; otherwise the body is sized to the whole container and its last rows
+  // overflow under the wrapper and get clipped (you can still scroll to them).
+  const [headerHeight, setHeaderHeight] = useState<number>(0);
   const [_data, setData] = useState<IReqoreTableData>(data || []);
   const [_sort, setSort] = useState<IReqoreTableSort | undefined>(fixSort(sort));
   const [_selected, setSelected] = useState<(string | number)[]>(selected || []);
@@ -356,6 +361,21 @@ const ReqoreTable = ({
 
   const addModal = useReqoreProperty('addModal');
   const [wrapperRef, sizes] = useMeasure();
+
+  // Track the header's height so a filled body can subtract it (see `headerHeight`).
+  // A ResizeObserver keeps it correct when the filter row appears/disappears or
+  // the header wraps. Only needed while `fill` is on.
+  useEffect(() => {
+    const element = mainHeaderRef.current;
+    if (!fill || !element || typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+    const measure = () => setHeaderHeight(element.offsetHeight);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [fill]);
   const { query, preQuery, setQuery, setPreQuery } = useQueryWithDelay(
     filter.toString(),
     300,
@@ -864,7 +884,7 @@ const ReqoreTable = ({
             headerRef={mainHeaderRef}
             data={items}
             columns={finalColumns}
-            height={fill ? sizes.height : height}
+            height={fill ? Math.max(0, sizes.height - headerHeight) : height}
             selectable={selectable}
             onSelectClick={handleSelectClick}
             onRowClick={onRowClick}


### PR DESCRIPTION
## Problem

When a `<ReqoreTable>` uses `fill`, the virtualized body is sized to the full measured container height (`sizes.height`). But the column/filter **header** sits *above* the body inside the same `StyledTableWrapper`, so the body overflows the wrapper by exactly the header's height. The result: the table's **last row(s) are clipped** under the wrapper edge — reachable only by scrolling them back into view, which reads as "the table has ~20px hidden under its wrapper."

This affects any `fill` table, and is more visible with `filterable` (the filter row makes the header taller).

### Root cause (measured)

In `Table/index.tsx` the body height was:

```tsx
height={fill ? sizes.height : height}
```

`sizes.height` is the whole content area (header + body), so the body got the full height with no room left for the header.

DOM measurements on a filled, overflowing table:
- body list bottom sat **+70px past** the wrapper bottom → last row not visible.
- forcing the list height to `wrapperHeight − headerHeight` → overflow **0**, body scrolls internally as intended.

## Fix

Measure the header height with a `ResizeObserver` and subtract it from the filled body height:

```tsx
height={fill ? Math.max(0, sizes.height - headerHeight) : height}
```

The observer keeps `headerHeight` correct when the filter row appears/disappears or the header wraps, and only runs while `fill` is on. No behaviour change when `fill` is off.

## Verification

- `yarn lint` — clean
- `yarn test __tests__/table.test.tsx` — 18/18 pass
- `yarn build` (prod tsc) — compiles
- Verified in the browser: with the corrected height the body no longer overflows its wrapper (70px → 0) and overflow rows are reached via the body's internal scroll.

Patch version bumped to **0.70.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)