### PR TITLE
Fix styling props leaking into DOM elements

### DIFF
--- a/__tests__/control_group.test.tsx
+++ b/__tests__/control_group.test.tsx
@@ -5,6 +5,7 @@ import {
   ReqoreControlGroup,
   ReqoreInput,
   ReqoreLayoutContent,
+  ReqoreMessage,
   ReqoreUIProvider,
 } from '../src';
 
@@ -29,4 +30,59 @@ test('Renders <ControlGroup /> properly', () => {
   expect(document.querySelectorAll('.reqore-input').length).toBe(3);
   expect(document.querySelectorAll('.reqore-button').length).toBe(3);
   expect(document.querySelectorAll('.reqore-control-group').length).toBe(1);
+});
+
+test('Does not forward ControlGroup styling props to the DOM', () => {
+  const { container } = render(
+    <ReqoreUIProvider>
+      <ReqoreControlGroup fluid vertical spaceBetween gapSize='small'>
+        <ReqoreButton>Hello</ReqoreButton>
+      </ReqoreControlGroup>
+    </ReqoreUIProvider>
+  );
+
+  const group = container.querySelector('.reqore-control-group');
+  expect(group).toBeTruthy();
+  expect(group).not.toHaveAttribute('fluid');
+  expect(group).not.toHaveAttribute('vertical');
+  expect(group).not.toHaveAttribute('spaceBetween');
+  expect(group).not.toHaveAttribute('gapSize');
+});
+
+test('Does not forward inherited ControlGroup props through polymorphic components', () => {
+  const { container } = render(
+    <ReqoreUIProvider>
+      <ReqoreControlGroup fluid vertical spaceBetween>
+        <ReqoreMessage fluid>Review this action</ReqoreMessage>
+      </ReqoreControlGroup>
+    </ReqoreUIProvider>
+  );
+
+  const message = container.querySelector('.reqore-message');
+  expect(message).toBeTruthy();
+  expect(message).not.toHaveAttribute('fluid');
+  expect(message).not.toHaveAttribute('spaceBetween');
+  expect(message).not.toHaveAttribute('asMessage');
+});
+
+test('Does not clone Reqore styling props onto intrinsic children', () => {
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  const { container } = render(
+    <ReqoreUIProvider>
+      <ReqoreControlGroup fluid vertical spaceBetween>
+        <ul data-testid='native-list'>
+          <li>Planned object</li>
+        </ul>
+      </ReqoreControlGroup>
+    </ReqoreUIProvider>
+  );
+
+  const list = container.querySelector('[data-testid="native-list"]');
+  const warnings = consoleError.mock.calls.flat().join(' ');
+  consoleError.mockRestore();
+  expect(list).toBeTruthy();
+  expect(list).not.toHaveAttribute('fluid');
+  expect(list).not.toHaveAttribute('spaceBetween');
+  expect(list).not.toHaveAttribute('customTheme');
+  expect(warnings).not.toMatch(/fluid|spaceBetween|customTheme/);
 });

--- a/__tests__/drawer.test.tsx
+++ b/__tests__/drawer.test.tsx
@@ -113,6 +113,20 @@ test('Renders <Drawer /> with interactive backdrop', () => {
   expect(fn).toHaveBeenCalled();
 });
 
+test('Does not forward backdrop styling props to the DOM', () => {
+  const { container } = render(
+    <ReqoreUIProvider>
+      <ReqoreDrawer isOpen hasBackdrop blur={4} />
+    </ReqoreUIProvider>
+  );
+
+  const backdrop = container.querySelector('.reqore-drawer-backdrop');
+  expect(backdrop).toBeTruthy();
+  expect(backdrop).not.toHaveAttribute('zIndex');
+  expect(backdrop).not.toHaveAttribute('blur');
+  expect(backdrop).not.toHaveAttribute('closable');
+});
+
 const CustomDrawer = () => {
   const [count, setCount] = React.useState(0);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.70.8",
+  "version": "0.70.9",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/ControlGroup/index.tsx
+++ b/src/components/ControlGroup/index.tsx
@@ -68,7 +68,24 @@ export interface IReqoreControlGroupStyle extends IReqoreControlGroupProps {
   theme: IReqoreTheme;
 }
 
-export const StyledReqoreControlGroup = styled(StyledEffect)<IReqoreControlGroupStyle>`
+const controlGroupStyleProps = new Set([
+  'fill',
+  'fixed',
+  'fluid',
+  'gapSize',
+  'horizontalAlign',
+  'rounded',
+  'spaceBetween',
+  'stack',
+  'vertical',
+  'verticalAlign',
+  'wrap',
+]);
+
+export const StyledReqoreControlGroup = styled(StyledEffect).withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    !controlGroupStyleProps.has(prop) && defaultValidatorFn(prop),
+})<IReqoreControlGroupStyle>`
   display: flex;
   flex: ${({ fluid, fixed }) => (fixed ? '0 0 auto' : fluid ? undefined : '0 0 auto')};
   width: ${({ fluid, fixed }) => (fluid && !fixed ? '100%' : undefined)};
@@ -405,22 +422,28 @@ const ReqoreControlGroup = memo(
     };
 
     const { clone } = useCloneThroughFragments(
-      (props, _index, index) => {
-        let newProps: any = {
-          ...props,
-          key: props.reactKey || _index,
-          minimal: props?.minimal || props?.minimal === false ? props.minimal : minimal,
-          size: props?.size || size,
-          flat: props?.flat || props?.flat === false ? props.flat : flat,
-          fluid: props?.fluid || props?.fluid === false ? props.fluid : fluid,
-          fixed: props?.fixed || props?.fixed === false ? props.fixed : fixed,
-          fill: props?.fill || props?.fill === false ? props.fill : fill,
-          spaceBetween:
-            props?.spaceBetween || props?.spaceBetween === false ? props.spaceBetween : false,
-          stack: props?.stack || props?.stack === false ? props.stack : isStack,
-          intent: props?.intent || intent,
-          customTheme: props?.customTheme || customTheme,
-        };
+      (props, _index, index, childType) => {
+        const isIntrinsicElement = typeof childType === 'string';
+        let newProps: any = isIntrinsicElement
+          ? {
+              ...props,
+              key: props.reactKey || _index,
+            }
+          : {
+              ...props,
+              key: props.reactKey || _index,
+              minimal: props?.minimal || props?.minimal === false ? props.minimal : minimal,
+              size: props?.size || size,
+              flat: props?.flat || props?.flat === false ? props.flat : flat,
+              fluid: props?.fluid || props?.fluid === false ? props.fluid : fluid,
+              fixed: props?.fixed || props?.fixed === false ? props.fixed : fixed,
+              fill: props?.fill || props?.fill === false ? props.fill : fill,
+              spaceBetween:
+                props?.spaceBetween || props?.spaceBetween === false ? props.spaceBetween : false,
+              stack: props?.stack || props?.stack === false ? props.stack : isStack,
+              intent: props?.intent || intent,
+              customTheme: props?.customTheme || customTheme,
+            };
 
         if (isStack) {
           const childIsFlat = props?.flat || props?.flat === false ? props.flat : flat;
@@ -447,21 +470,24 @@ const ReqoreControlGroup = memo(
               borderBottomRightRadius: getBorderBottomRightRadius(index, props?.rounded),
               ...(props?.style || {}),
             },
-            isChild: true,
-            rounded: isMasterGroupRounded === false ? false : !isStack,
-            isMasterGroupRounded: isChild ? isMasterGroupRounded : rounded,
-            isInsideStackGroup: isStack,
-            isInsideVerticalGroup: isVertical,
-            isFirst: isChild ? getIsFirst(index) : undefined,
-            isLast: isChild ? getIsLast(index) : undefined,
-            isLastInFirstGroup: getIsLastInFirstGroup(index),
-            isLastInLastGroup: getIsLastInLastGroup(index),
-            isFirstInLastGroup: getIsFirstInLastGroup(index),
-            childrenCount: realChildCount,
-            childId: index + 1,
-
-            isFirstGroup: isChild ? isFirstGroup : index === 0,
-            isLastGroup: isChild ? isLastGroup : index === realChildCount - 1,
+            ...(!isIntrinsicElement
+              ? {
+                  isChild: true,
+                  rounded: isMasterGroupRounded === false ? false : !isStack,
+                  isMasterGroupRounded: isChild ? isMasterGroupRounded : rounded,
+                  isInsideStackGroup: isStack,
+                  isInsideVerticalGroup: isVertical,
+                  isFirst: isChild ? getIsFirst(index) : undefined,
+                  isLast: isChild ? getIsLast(index) : undefined,
+                  isLastInFirstGroup: getIsLastInFirstGroup(index),
+                  isLastInLastGroup: getIsLastInLastGroup(index),
+                  isFirstInLastGroup: getIsFirstInLastGroup(index),
+                  childrenCount: realChildCount,
+                  childId: index + 1,
+                  isFirstGroup: isChild ? isFirstGroup : index === 0,
+                  isLastGroup: isChild ? isLastGroup : index === realChildCount - 1,
+                }
+              : {}),
           };
         }
 

--- a/src/components/ControlGroup/index.tsx
+++ b/src/components/ControlGroup/index.tsx
@@ -427,26 +427,25 @@ const ReqoreControlGroup = memo(
         let newProps: any = isIntrinsicElement
           ? {
               ...props,
-              key: props.reactKey || _index,
+              key: props?.reactKey || _index,
             }
           : {
               ...props,
-              key: props.reactKey || _index,
-              minimal: props?.minimal || props?.minimal === false ? props.minimal : minimal,
+              key: props?.reactKey || _index,
+              minimal: props?.minimal ?? minimal,
               size: props?.size || size,
-              flat: props?.flat || props?.flat === false ? props.flat : flat,
-              fluid: props?.fluid || props?.fluid === false ? props.fluid : fluid,
-              fixed: props?.fixed || props?.fixed === false ? props.fixed : fixed,
-              fill: props?.fill || props?.fill === false ? props.fill : fill,
-              spaceBetween:
-                props?.spaceBetween || props?.spaceBetween === false ? props.spaceBetween : false,
-              stack: props?.stack || props?.stack === false ? props.stack : isStack,
+              flat: props?.flat ?? flat,
+              fluid: props?.fluid ?? fluid,
+              fixed: props?.fixed ?? fixed,
+              fill: props?.fill ?? fill,
+              spaceBetween: props?.spaceBetween ?? false,
+              stack: props?.stack ?? isStack,
               intent: props?.intent || intent,
               customTheme: props?.customTheme || customTheme,
             };
 
         if (isStack) {
-          const childIsFlat = props?.flat || props?.flat === false ? props.flat : flat;
+          const childIsFlat = props?.flat ?? flat;
           const needsCollapse = !childIsFlat;
           const isFirstChild = index === 0;
 

--- a/src/components/Drawer/backdrop.tsx
+++ b/src/components/Drawer/backdrop.tsx
@@ -13,7 +13,12 @@ export interface IReqoreBackdropProps extends React.HTMLAttributes<HTMLDivElemen
   opacity?: number;
 }
 
-export const StyledBackdrop = styled(animated.div)<
+const backdropStyleProps = new Set(['blur', 'closable', 'zIndex']);
+
+export const StyledBackdrop = styled(animated.div).withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    !backdropStyleProps.has(prop) && defaultValidatorFn(prop),
+})<
   IReqoreDrawerStyle & { closable: boolean; zIndex?: number }
 >`
   position: fixed;

--- a/src/components/Notifications/notification.tsx
+++ b/src/components/Notifications/notification.tsx
@@ -91,7 +91,26 @@ const timeoutAnimation = keyframes`
   }
 `;
 
-export const StyledReqoreNotification = styled(StyledEffect)<IReqoreNotificationStyle>`
+const notificationStyleProps = new Set([
+  'asMessage',
+  'backgroundBlur',
+  'clickable',
+  'fill',
+  'fixed',
+  'flat',
+  'fluid',
+  'hasShadow',
+  'margin',
+  'raised',
+  'spaceBetween',
+  'stack',
+  'timeout',
+]);
+
+export const StyledReqoreNotification = styled(StyledEffect).withConfig({
+  shouldForwardProp: (prop, defaultValidatorFn) =>
+    !notificationStyleProps.has(prop) && defaultValidatorFn(prop),
+})<IReqoreNotificationStyle>`
   min-width: ${({ fluid }) => (!fluid ? '30px' : undefined)};
   max-width: ${({ maxWidth, fluid, fixed }) => maxWidth || (fluid && !fixed ? '100%' : undefined)};
   border-radius: 5px;

--- a/src/hooks/useCloneThroughFragments.ts
+++ b/src/hooks/useCloneThroughFragments.ts
@@ -4,7 +4,8 @@ export const useCloneThroughFragments = (
   propsMapper: (
     props: Record<string | number, any>,
     reactIndex: number,
-    realIndex: number
+    realIndex: number,
+    childType: React.ReactElement['type']
   ) => Record<string | number, any>,
   deps?: any[]
 ) => {
@@ -17,7 +18,7 @@ export const useCloneThroughFragments = (
           return clone(child.props.children);
         }
 
-        const props = propsMapper(child.props, reactIndex, realIndex);
+        const props = propsMapper(child.props, reactIndex, realIndex, child.type);
 
         /*
          * Because of the way React.Children.map works, we have to


### PR DESCRIPTION
## Summary
- filter ControlGroup, notification, and drawer styling props before native DOM rendering
- avoid cloning ReQore-only props onto intrinsic ControlGroup children
- add regression coverage for wrapper, polymorphic, intrinsic-child, and backdrop paths

## Verification
- `yarn test` (700 tests)
- `yarn lint`
- `yarn build:test:prod`
- `yarn test:stories` (862 browser stories reported passed; known Qlip/Vitest teardown issue leaves the completed runner resident)