### PR TITLE
feat(Timeline): collapsible ranges — fold a run of items behind an "N hidden" marker

### DIFF
--- a/__tests__/Timeline.test.tsx
+++ b/__tests__/Timeline.test.tsx
@@ -498,3 +498,82 @@ test('Renders <Timeline /> title-only items with connecting lines', () => {
   expect(document.querySelectorAll('.reqore-timeline-item').length).toBe(3);
   expect(document.querySelectorAll('.reqore-icon').length).toBe(3);
 });
+
+test('Collapsed range: folds items behind an "N hidden" marker until expanded', () => {
+  render(
+    <ReqoreUIProvider>
+      <ReqoreLayoutContent>
+        <ReqoreContent>
+          <ReqoreTimeline
+            items={[
+              { title: 'Head', content: 'Head content' },
+              {
+                collapsedItems: [
+                  { title: 'Hidden A', content: 'A content' },
+                  { title: 'Hidden B', content: 'B content' },
+                ],
+              },
+              { title: 'Tail', content: 'Tail content' },
+            ]}
+          />
+        </ReqoreContent>
+      </ReqoreLayoutContent>
+    </ReqoreUIProvider>
+  );
+
+  // The fold marker shows "2 hidden"; the hidden items are not rendered yet.
+  const run = document.querySelector('.reqore-timeline-collapsed-run')!;
+  expect(run).toBeTruthy();
+  expect(screen.getByText('2 hidden')).toBeTruthy();
+  expect(screen.queryByText('Hidden A')).toBeNull();
+  expect(screen.queryByText('Hidden B')).toBeNull();
+  // Head + Tail + the run marker = 3 timeline items.
+  expect(document.querySelectorAll('.reqore-timeline-item').length).toBe(3);
+
+  // Expanding the run reveals the hidden items inline.
+  fireEvent.click(run);
+  expect(screen.getByText('Hidden A')).toBeTruthy();
+  expect(screen.getByText('Hidden B')).toBeTruthy();
+  // Now shows a "Hide" control to re-fold.
+  expect(screen.getByText('Hide')).toBeTruthy();
+
+  // Re-folding hides them again.
+  fireEvent.click(document.querySelector('.reqore-timeline-collapsed-run')!);
+  expect(screen.queryByText('Hidden A')).toBeNull();
+});
+
+test('Collapsed range: custom label, defaultExpanded and onRangeToggle', () => {
+  const onRangeToggle = vi.fn();
+  render(
+    <ReqoreUIProvider>
+      <ReqoreLayoutContent>
+        <ReqoreContent>
+          <ReqoreTimeline
+            onRangeToggle={onRangeToggle}
+            items={[
+              {
+                label: '3 read-only builds',
+                defaultExpanded: true,
+                collapsedItems: [
+                  { title: 'Build 3' },
+                  { title: 'Build 2' },
+                  { title: 'Build 1' },
+                ],
+              },
+            ]}
+          />
+        </ReqoreContent>
+      </ReqoreLayoutContent>
+    </ReqoreUIProvider>
+  );
+
+  // defaultExpanded → the items render immediately and the control reads "Hide".
+  expect(screen.getByText('Build 2')).toBeTruthy();
+  expect(screen.getByText('Hide')).toBeTruthy();
+
+  // Re-folding fires onRangeToggle(index, false) and shows the custom label.
+  fireEvent.click(document.querySelector('.reqore-timeline-collapsed-run')!);
+  expect(onRangeToggle).toHaveBeenCalledWith(0, false);
+  expect(screen.getByText('3 read-only builds')).toBeTruthy();
+  expect(screen.queryByText('Build 2')).toBeNull();
+});

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@docusaurus/core": "^3.6.0",
     "@docusaurus/preset-classic": "^3.6.0",
-    "@qoretechnologies/qlip": "^0.1.3-beta.20260622084321",
+    "@qoretechnologies/qlip": "^0.1.3-beta.20260715110527",
     "@storybook/addon-docs": "^10.4.3",
     "@storybook/addon-links": "^10.4.3",
     "@storybook/addon-vitest": "^10.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.70.9",
+  "version": "0.70.10",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/COMPONENTS.md
+++ b/src/components/COMPONENTS.md
@@ -64,6 +64,6 @@
 | **ReqoreTextarea** | Multi-line text input with optional auto-sizing, clear button, and template variable support. Accepts an optional `radiusSize` (`TSizes`) that overrides the `size`-derived corner roundness using the pronounced `RADIUS_FROM_RADIUS_SIZE` scale. |
 | **ReqoreTier** | Pricing/feature tier card component with highlighted states, price display, and feature lists. |
 | **TimeAgo** | Relative time display component (e.g., "2 hours ago") that updates periodically. |
-| **ReqoreTimeline** | Vertical timeline component displaying chronological events with optional icons, timestamps, and collapsible content. |
+| **ReqoreTimeline** | Vertical timeline component displaying chronological events with optional icons, timestamps, and collapsible content. Supports folding a run of items into a single "N hidden" marker (`IReqoreTimelineCollapsedRange`) that expands on click, GitHub-diff style. |
 | **ReqoreTooltipComponent** | Wrapper component that attaches tooltips to other components via Popover. |
 | **ReqoreTree** | Hierarchical tree view component for displaying nested data structures with optional editing and expansion controls. |

--- a/src/components/Timeline/index.tsx
+++ b/src/components/Timeline/index.tsx
@@ -66,6 +66,34 @@ export interface IReqoreTimelineItem extends IReqoreDisabled, IReqoreIntent {
   contentEffect?: IReqoreEffect;
 }
 
+/**
+ * A folded run of timeline items, rendered as a single compact "N hidden"
+ * marker that expands the hidden items inline on click (GitHub-diff style).
+ * Purely visual — the caller decides which consecutive items to fold and
+ * passes them here. Only honored in vertical mode.
+ */
+export interface IReqoreTimelineCollapsedRange {
+  /** The items hidden inside this run. */
+  collapsedItems: IReqoreTimelineItem[];
+  /** Text next to the dots; defaults to `${n} hidden`. */
+  label?: string;
+  /** Marker icon for the folded run; defaults to a vertical 3-dots. */
+  icon?: IReqoreIconName;
+  iconColor?: TReqoreEffectColor;
+  /** Start expanded. Defaults to `false` (folded). */
+  defaultExpanded?: boolean;
+}
+
+/** A timeline entry: either a normal item or a folded run of items. */
+export type TReqoreTimelineEntry = IReqoreTimelineItem | IReqoreTimelineCollapsedRange;
+
+/** Narrows a timeline entry to a folded run. */
+export function isReqoreTimelineCollapsedRange(
+  entry: TReqoreTimelineEntry
+): entry is IReqoreTimelineCollapsedRange {
+  return 'collapsedItems' in entry && Array.isArray(entry.collapsedItems);
+}
+
 export interface IReqoreTimelineProps
   extends Omit<React.HTMLAttributes<HTMLOListElement>, 'children'>,
     IReqoreComponent,
@@ -73,8 +101,12 @@ export interface IReqoreTimelineProps
     IReqoreIntent,
     IWithReqoreFluid,
     IWithReqoreSize {
-  /** Array of timeline items to display */
-  items: IReqoreTimelineItem[];
+  /**
+   * Array of timeline entries to display. An entry is either a normal
+   * `IReqoreTimelineItem` or an `IReqoreTimelineCollapsedRange` — a folded run
+   * of items shown as a single "N hidden" marker that expands on click.
+   */
+  items: TReqoreTimelineEntry[];
   /**
    * Layout direction. `'vertical'` stacks items top-to-bottom (default).
    * `'horizontal'` lays them out left-to-right with the connector line between markers.
@@ -97,6 +129,11 @@ export interface IReqoreTimelineProps
   collapsedState?: Record<number, boolean>;
   /** Callback fired when any item's collapsed state changes (click, keyboard, etc.) */
   onCollapseChange?: (index: number, isCollapsed: boolean) => void;
+  /**
+   * Callback fired when a folded run (`IReqoreTimelineCollapsedRange`) is
+   * expanded or re-folded. `index` is the entry's index in `items`.
+   */
+  onRangeToggle?: (index: number, isExpanded: boolean) => void;
 }
 
 export interface IReqoreTimelineStyle {
@@ -344,7 +381,6 @@ const TimelineBadge = memo(({ size, content }: IBadgeProps) => {
 
 interface ITimelineItemRendererProps {
   item: IReqoreTimelineItem;
-  index: number;
   isLast: boolean;
   size: TSizes;
   customTheme?: IReqoreTimelineProps['customTheme'];
@@ -352,7 +388,7 @@ interface ITimelineItemRendererProps {
   baseTheme: IReqoreTheme;
   isCollapsed: boolean;
   direction: 'vertical' | 'horizontal';
-  onToggleCollapse: (index: number, event: React.MouseEvent) => void;
+  onToggle: (event: React.MouseEvent) => void;
   onItemClick: (item: IReqoreTimelineItem) => void;
   onKeyDown: (event: React.KeyboardEvent, item: IReqoreTimelineItem) => void;
 }
@@ -360,7 +396,6 @@ interface ITimelineItemRendererProps {
 const TimelineItemRenderer = memo(
   ({
     item,
-    index,
     isLast,
     size,
     customTheme,
@@ -368,7 +403,7 @@ const TimelineItemRenderer = memo(
     baseTheme,
     isCollapsed,
     direction,
-    onToggleCollapse,
+    onToggle,
     onItemClick,
     onKeyDown,
   }: ITimelineItemRendererProps) => {
@@ -423,7 +458,7 @@ const TimelineItemRenderer = memo(
               horizontalAlign={isHorizontal ? 'center' : undefined}
               vertical={isHorizontal}
               gapSize={size}
-              onClick={showCollapsible ? (e) => onToggleCollapse(index, e) : undefined}
+              onClick={showCollapsible ? (e) => onToggle(e) : undefined}
               style={showCollapsible ? { cursor: 'pointer' } : undefined}
             >
               {showCollapsible && (
@@ -500,6 +535,81 @@ const TimelineItemRenderer = memo(
   }
 );
 
+interface ICollapsedRunRendererProps {
+  range: IReqoreTimelineCollapsedRange;
+  isLast: boolean;
+  size: TSizes;
+  baseTheme: IReqoreTheme;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * The folded "N hidden" marker for a collapsed run — one muted, clickable
+ * timeline node that stands in for the hidden items (or, when expanded, a
+ * "Hide" control that re-folds them). Vertical mode only.
+ */
+const CollapsedRunRenderer = memo(
+  ({ range, isLast, size, baseTheme, expanded, onToggle }: ICollapsedRunRendererProps) => {
+    const n = range.collapsedItems.length;
+    // Hex for the icon (ReqoreIcon `color` wants a TReqoreEffectColor); rgba for
+    // the label's plain CSS colour. Both muted to read as "skipped".
+    const mutedIconColor = changeLightness(baseTheme.main, 0.2);
+    const mutedTextColor = rgba(getReadableColor(baseTheme, undefined, undefined), 0.55);
+    const label = expanded ? 'Hide' : (range.label ?? `${n} hidden`);
+    return (
+      <StyledTimelineItem
+        theme={baseTheme}
+        size={size}
+        direction='vertical'
+        isClickable
+        isLast={isLast}
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
+        tabIndex={0}
+        role='listitem'
+        className='reqore-timeline-item reqore-timeline-collapsed-run'
+      >
+        <StyledTimelineMarkerWrapper theme={baseTheme} size={size} direction='vertical'>
+          <StyledTimelineMarker
+            theme={baseTheme}
+            size={size}
+            hasIntent={false}
+            className='reqore-timeline-marker'
+          >
+            <ReqoreIcon
+              icon={range.icon ?? (expanded ? 'ArrowUpSLine' : 'More2Line')}
+              size={getOneLessSize(getOneLessSize(size))}
+              color={range.iconColor ?? mutedIconColor}
+            />
+          </StyledTimelineMarker>
+          {!isLast && <StyledTimelineLine theme={baseTheme} size={size} isLast={isLast} />}
+        </StyledTimelineMarkerWrapper>
+        <StyledTimelineContent theme={baseTheme} size={size} direction='vertical'>
+          <ReqoreControlGroup
+            verticalAlign='center'
+            gapSize={size}
+            style={{ cursor: 'pointer' }}
+          >
+            <ReqoreSpan
+              size={size}
+              className='reqore-timeline-collapsed-run-label'
+              style={{ fontWeight: 500, color: mutedTextColor }}
+            >
+              {label}
+            </ReqoreSpan>
+          </ReqoreControlGroup>
+        </StyledTimelineContent>
+      </StyledTimelineItem>
+    );
+  }
+);
+
 const ReqoreTimeline = memo(
   forwardRef<HTMLOListElement, IReqoreTimelineProps>(
     (
@@ -515,6 +625,7 @@ const ReqoreTimeline = memo(
         responsive = true,
         collapsedState,
         onCollapseChange,
+        onRangeToggle,
         ...rest
       },
       ref
@@ -527,17 +638,34 @@ const ReqoreTimeline = memo(
       const direction =
         responsive && isMobile && directionProp === 'horizontal' ? 'vertical' : directionProp;
 
-      // Internal state used only in uncontrolled mode
+      // Internal collapse state for TOP-LEVEL items (uncontrolled mode). Folded
+      // runs are skipped here — they carry their own expand state below.
       const [internalCollapsedStates, setInternalCollapsedStates] = useState<
         Record<number, boolean>
       >(() =>
-        items.reduce((acc, item, index) => {
-          if (item.collapsible) {
-            acc[index] = item.isCollapsed ?? false;
+        items.reduce((acc, entry, index) => {
+          if (!isReqoreTimelineCollapsedRange(entry) && entry.collapsible) {
+            acc[index] = entry.isCollapsed ?? false;
           }
           return acc;
         }, {} as Record<number, boolean>)
       );
+
+      // Expand state per folded run (uncontrolled), seeded from `defaultExpanded`.
+      const [expandedRanges, setExpandedRanges] = useState<Record<number, boolean>>(() =>
+        items.reduce((acc, entry, index) => {
+          if (isReqoreTimelineCollapsedRange(entry)) {
+            acc[index] = entry.defaultExpanded ?? false;
+          }
+          return acc;
+        }, {} as Record<number, boolean>)
+      );
+
+      // Collapse state for items rendered INSIDE an expanded run, keyed by
+      // `${rangeIndex}-${nestedIndex}` (always uncontrolled).
+      const [nestedCollapsedStates, setNestedCollapsedStates] = useState<
+        Record<string, boolean>
+      >({});
 
       const isControlled = collapsedState !== undefined;
 
@@ -558,7 +686,10 @@ const ReqoreTimeline = memo(
         (index: number, event: React.MouseEvent) => {
           event.stopPropagation();
           if (isControlled) {
-            const currentCollapsed = collapsedState![index] ?? items[index]?.isCollapsed ?? false;
+            const entry = items[index];
+            const fallback =
+              entry && !isReqoreTimelineCollapsedRange(entry) ? entry.isCollapsed ?? false : false;
+            const currentCollapsed = collapsedState![index] ?? fallback;
             onCollapseChange?.(index, !currentCollapsed);
           } else {
             setInternalCollapsedStates((prev) => {
@@ -582,6 +713,97 @@ const ReqoreTimeline = memo(
         [isControlled, collapsedState, internalCollapsedStates]
       );
 
+      const getIsRangeExpanded = useCallback(
+        (range: IReqoreTimelineCollapsedRange, index: number): boolean =>
+          expandedRanges[index] ?? range.defaultExpanded ?? false,
+        [expandedRanges]
+      );
+
+      const toggleRange = useCallback(
+        (index: number, range: IReqoreTimelineCollapsedRange) => {
+          const next = !getIsRangeExpanded(range, index);
+          setExpandedRanges((prev) => ({ ...prev, [index]: next }));
+          onRangeToggle?.(index, next);
+        },
+        [getIsRangeExpanded, onRangeToggle]
+      );
+
+      const getNestedCollapsed = useCallback(
+        (item: IReqoreTimelineItem, key: string): boolean => {
+          if (!item.collapsible) return false;
+          return nestedCollapsedStates[key] ?? item.isCollapsed ?? false;
+        },
+        [nestedCollapsedStates]
+      );
+
+      const toggleNested = useCallback(
+        (key: string, item: IReqoreTimelineItem, event: React.MouseEvent) => {
+          event.stopPropagation();
+          setNestedCollapsedStates((prev) => ({
+            ...prev,
+            [key]: !(prev[key] ?? item.isCollapsed ?? false),
+          }));
+        },
+        []
+      );
+
+      // Flatten entries into the render sequence: normal items, plus a fold
+      // marker per collapsed run (followed by its items when expanded). `isLast`
+      // (the connector line) is computed over THIS flattened order so it never
+      // breaks across an expanded run.
+      type TRenderRow =
+        | {
+            kind: 'item';
+            item: IReqoreTimelineItem;
+            isCollapsed: boolean;
+            onToggle: (event: React.MouseEvent) => void;
+            key: string;
+          }
+        | {
+            kind: 'run';
+            range: IReqoreTimelineCollapsedRange;
+            expanded: boolean;
+            onToggle: () => void;
+            key: string;
+          };
+
+      const rows: TRenderRow[] = [];
+      items.forEach((entry, entryIndex) => {
+        if (!isReqoreTimelineCollapsedRange(entry)) {
+          rows.push({
+            kind: 'item',
+            item: entry,
+            isCollapsed: getIsCollapsed(entry, entryIndex),
+            onToggle: (event) => toggleCollapse(entryIndex, event),
+            key: `i${entryIndex}`,
+          });
+          return;
+        }
+        // A folded run. Horizontal mode has no fold affordance — inline the items.
+        const expanded = direction === 'horizontal' || getIsRangeExpanded(entry, entryIndex);
+        if (direction === 'vertical') {
+          rows.push({
+            kind: 'run',
+            range: entry,
+            expanded,
+            onToggle: () => toggleRange(entryIndex, entry),
+            key: `r${entryIndex}`,
+          });
+        }
+        if (expanded) {
+          entry.collapsedItems.forEach((nested, nestedIndex) => {
+            const nestedKey = `${entryIndex}-${nestedIndex}`;
+            rows.push({
+              kind: 'item',
+              item: nested,
+              isCollapsed: getNestedCollapsed(nested, nestedKey),
+              onToggle: (event) => toggleNested(nestedKey, nested, event),
+              key: `n${nestedKey}`,
+            });
+          });
+        }
+      });
+
       return (
         <StyledTimeline
           {...rest}
@@ -593,23 +815,38 @@ const ReqoreTimeline = memo(
           className={`${className || ''} reqore-timeline reqore-timeline-${direction}`}
           role='list'
         >
-          {items.map((item, index) => (
-            <TimelineItemRenderer
-              key={index}
-              item={item}
-              index={index}
-              isLast={index === items.length - 1}
-              size={size}
-              customTheme={customTheme}
-              intent={intent}
-              baseTheme={baseTheme}
-              direction={direction}
-              isCollapsed={getIsCollapsed(item, index)}
-              onToggleCollapse={toggleCollapse}
-              onItemClick={handleItemClick}
-              onKeyDown={handleKeyDown}
-            />
-          ))}
+          {rows.map((row, rowIndex) => {
+            const isLast = rowIndex === rows.length - 1;
+            if (row.kind === 'run') {
+              return (
+                <CollapsedRunRenderer
+                  key={row.key}
+                  range={row.range}
+                  isLast={isLast}
+                  size={size}
+                  baseTheme={baseTheme}
+                  expanded={row.expanded}
+                  onToggle={row.onToggle}
+                />
+              );
+            }
+            return (
+              <TimelineItemRenderer
+                key={row.key}
+                item={row.item}
+                isLast={isLast}
+                size={size}
+                customTheme={customTheme}
+                intent={intent}
+                baseTheme={baseTheme}
+                direction={direction}
+                isCollapsed={row.isCollapsed}
+                onToggle={row.onToggle}
+                onItemClick={handleItemClick}
+                onKeyDown={handleKeyDown}
+              />
+            );
+          })}
         </StyledTimeline>
       );
     }

--- a/src/components/Timeline/index.tsx
+++ b/src/components/Timeline/index.tsx
@@ -614,7 +614,12 @@ const CollapsedRunRenderer = memo(
             />
           </StyledTimelineMarker>
           {!isLast && (
-            <StyledTimelineLine theme={baseTheme} size={size} isLast={isLast} dashed />
+            <StyledTimelineLine
+              theme={baseTheme}
+              size={size}
+              isLast={isLast}
+              dashed={!expanded}
+            />
           )}
         </StyledTimelineMarkerWrapper>
         <StyledTimelineContent theme={baseTheme} size={size} direction='vertical'>
@@ -858,8 +863,11 @@ const ReqoreTimeline = memo(
               );
             }
             // A normal item's downward connector goes dotted when the next
-            // entry is a collapsed run — the dotted boundary reads as "folded".
-            const lineDashed = rows[rowIndex + 1]?.kind === 'run';
+            // entry is a *folded* run — the dotted boundary reads as "hidden".
+            // An expanded run reveals its items, so that line stays solid.
+            const nextRow = rows[rowIndex + 1];
+            const lineDashed =
+              nextRow !== undefined && nextRow.kind === 'run' && !nextRow.expanded;
             return (
               <TimelineItemRenderer
                 key={row.key}

--- a/src/components/Timeline/index.tsx
+++ b/src/components/Timeline/index.tsx
@@ -149,6 +149,8 @@ export interface IReqoreTimelineItemStyle extends IReqoreTimelineStyle {
   disabled?: boolean;
   hasIntent?: boolean;
   isCollapsed?: boolean;
+  /** Render the connector line dotted (used around a collapsed run). */
+  dashed?: boolean;
 }
 
 // Size of the timeline marker (icon container) - made smaller
@@ -289,7 +291,22 @@ const StyledTimelineLine = styled.div<IReqoreTimelineItemStyle>`
   top: ${({ size }) => MARKER_SIZE_FROM_SIZE[size]}px;
   bottom: 0;
   width: ${({ size }) => LINE_WIDTH_FROM_SIZE[size]}px;
-  background-color: ${({ theme }) => rgba(changeLightness(theme.main, 0.1), 0.4)};
+
+  ${({ dashed, theme }) =>
+    dashed
+      ? css`
+          /* Dotted connector — signals the folded/skipped run boundary. */
+          background-image: linear-gradient(
+            to bottom,
+            ${rgba(changeLightness(theme.main, 0.2), 0.6)} 0 3px,
+            transparent 3px 7px
+          );
+          background-size: 100% 7px;
+          background-repeat: repeat-y;
+        `
+      : css`
+          background-color: ${rgba(changeLightness(theme.main, 0.1), 0.4)};
+        `}
 
   ${({ isLast }) =>
     isLast &&
@@ -388,6 +405,8 @@ interface ITimelineItemRendererProps {
   baseTheme: IReqoreTheme;
   isCollapsed: boolean;
   direction: 'vertical' | 'horizontal';
+  /** Draw this item's downward connector dotted (next to a collapsed run). */
+  lineDashed?: boolean;
   onToggle: (event: React.MouseEvent) => void;
   onItemClick: (item: IReqoreTimelineItem) => void;
   onKeyDown: (event: React.KeyboardEvent, item: IReqoreTimelineItem) => void;
@@ -403,6 +422,7 @@ const TimelineItemRenderer = memo(
     baseTheme,
     isCollapsed,
     direction,
+    lineDashed,
     onToggle,
     onItemClick,
     onKeyDown,
@@ -448,7 +468,12 @@ const TimelineItemRenderer = memo(
             )}
           </StyledTimelineMarker>
           {!isHorizontal && (
-            <StyledTimelineLine theme={baseTheme} size={size} isLast={isLast} />
+            <StyledTimelineLine
+              theme={baseTheme}
+              size={size}
+              isLast={isLast}
+              dashed={lineDashed}
+            />
           )}
         </StyledTimelineMarkerWrapper>
         <StyledTimelineContent theme={baseTheme} size={size} direction={direction}>
@@ -588,7 +613,9 @@ const CollapsedRunRenderer = memo(
               color={range.iconColor ?? mutedIconColor}
             />
           </StyledTimelineMarker>
-          {!isLast && <StyledTimelineLine theme={baseTheme} size={size} isLast={isLast} />}
+          {!isLast && (
+            <StyledTimelineLine theme={baseTheme} size={size} isLast={isLast} dashed />
+          )}
         </StyledTimelineMarkerWrapper>
         <StyledTimelineContent theme={baseTheme} size={size} direction='vertical'>
           <ReqoreControlGroup
@@ -830,6 +857,9 @@ const ReqoreTimeline = memo(
                 />
               );
             }
+            // A normal item's downward connector goes dotted when the next
+            // entry is a collapsed run — the dotted boundary reads as "folded".
+            const lineDashed = rows[rowIndex + 1]?.kind === 'run';
             return (
               <TimelineItemRenderer
                 key={row.key}
@@ -841,6 +871,7 @@ const ReqoreTimeline = memo(
                 baseTheme={baseTheme}
                 direction={direction}
                 isCollapsed={row.isCollapsed}
+                lineDashed={lineDashed}
                 onToggle={row.onToggle}
                 onItemClick={handleItemClick}
                 onKeyDown={handleKeyDown}

--- a/src/stories/Timeline/Timeline.stories.tsx
+++ b/src/stories/Timeline/Timeline.stories.tsx
@@ -1,4 +1,4 @@
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, within } from 'storybook/test';
 import { StoryFn, StoryObj } from '@storybook/react';
 import { useCallback, useEffect, useState } from 'react';
 import { _testsClickButton } from '../../../__tests__/utils';
@@ -852,7 +852,8 @@ export const WorkflowExample: Story = {
 
 // A folded run of uneventful items (GitHub-diff style): only the noteworthy
 // entries stay visible, the rest collapse behind an "N hidden" marker that
-// expands on click.
+// expands on click. Runs can sit between normal entries as well as at the
+// ends, and their connector line is dotted to read as "skipped".
 export const CollapsedRange: Story = {
   render: (args) => (
     <ReqoreTimeline
@@ -885,10 +886,27 @@ export const CollapsedRange: Story = {
           collapsible: true,
         },
         {
+          // A run sandwiched between two normal entries (#11 above, #7 below).
           label: '2 read-only builds',
           collapsedItems: [
             { title: 'Build #10', timestamp: 'Jul 9', icon: 'TimeLine' },
             { title: 'Build #1', timestamp: 'Jul 9', icon: 'TimeLine' },
+          ],
+        },
+        {
+          title: 'Build #7',
+          content: 'Accepted',
+          timestamp: 'Jul 8',
+          icon: 'CheckLine',
+          intent: 'success',
+          collapsible: true,
+        },
+        {
+          label: '3 read-only builds',
+          collapsedItems: [
+            { title: 'Build #6', timestamp: 'Jul 8', icon: 'TimeLine' },
+            { title: 'Build #5', timestamp: 'Jul 7', icon: 'TimeLine' },
+            { title: 'Build #4', timestamp: 'Jul 7', icon: 'TimeLine' },
           ],
         },
       ]}
@@ -896,17 +914,14 @@ export const CollapsedRange: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    // Folded runs show their labels; the hidden builds aren't rendered yet.
+    // Folded runs show their labels; the hidden builds aren't rendered.
     await expect(canvas.getByText('6 read-only builds')).toBeInTheDocument();
+    await expect(canvas.getByText('2 read-only builds')).toBeInTheDocument();
     await expect(canvas.queryByText('Build #14')).not.toBeInTheDocument();
-    // The noteworthy rejection stays visible.
+    await expect(canvas.queryByText('Build #10')).not.toBeInTheDocument();
+    // Noteworthy entries stay visible — including a normal entry sandwiched
+    // between two collapsed runs.
     await expect(canvas.getByText('Build #11')).toBeInTheDocument();
-    // Expanding the first run reveals its hidden builds + a "Hide" control.
-    const run = canvasElement.querySelector(
-      '.reqore-timeline-collapsed-run'
-    ) as HTMLElement;
-    await userEvent.click(run);
-    await expect(canvas.getByText('Build #14')).toBeInTheDocument();
-    await expect(canvas.getByText('Hide')).toBeInTheDocument();
+    await expect(canvas.getByText('Build #7')).toBeInTheDocument();
   },
 };

--- a/src/stories/Timeline/Timeline.stories.tsx
+++ b/src/stories/Timeline/Timeline.stories.tsx
@@ -1,4 +1,4 @@
-import { expect, within } from 'storybook/test';
+import { expect, userEvent, within } from 'storybook/test';
 import { StoryFn, StoryObj } from '@storybook/react';
 import { useCallback, useEffect, useState } from 'react';
 import { _testsClickButton } from '../../../__tests__/utils';
@@ -848,4 +848,65 @@ export const WorkflowExample: Story = {
       ]}
     />
   ),
+};
+
+// A folded run of uneventful items (GitHub-diff style): only the noteworthy
+// entries stay visible, the rest collapse behind an "N hidden" marker that
+// expands on click.
+export const CollapsedRange: Story = {
+  render: (args) => (
+    <ReqoreTimeline
+      {...args}
+      items={[
+        {
+          title: 'Build #18 · reviewing now',
+          timestamp: 'Jul 15',
+          icon: 'TimeLine',
+          intent: 'info',
+        },
+        {
+          label: '6 read-only builds',
+          collapsedItems: [
+            { title: 'Build #17', timestamp: 'Jul 15', icon: 'TimeLine' },
+            { title: 'Build #16', timestamp: 'Jul 15', icon: 'TimeLine' },
+            { title: 'Build #15', timestamp: 'Jul 15', icon: 'TimeLine' },
+            { title: 'Build #14', timestamp: 'Jul 15', icon: 'TimeLine' },
+            { title: 'Build #13', timestamp: 'Jul 14', icon: 'TimeLine' },
+            { title: 'Build #12', timestamp: 'Jul 14', icon: 'TimeLine' },
+          ],
+        },
+        {
+          title: 'Build #11',
+          content: 'Rejected — empty render.',
+          timestamp: 'Jul 9',
+          icon: 'CloseCircleLine',
+          intent: 'danger',
+          badge: [{ label: '1', icon: 'Chat1Line' }],
+          collapsible: true,
+        },
+        {
+          label: '2 read-only builds',
+          collapsedItems: [
+            { title: 'Build #10', timestamp: 'Jul 9', icon: 'TimeLine' },
+            { title: 'Build #1', timestamp: 'Jul 9', icon: 'TimeLine' },
+          ],
+        },
+      ]}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Folded runs show their labels; the hidden builds aren't rendered yet.
+    await expect(canvas.getByText('6 read-only builds')).toBeInTheDocument();
+    await expect(canvas.queryByText('Build #14')).not.toBeInTheDocument();
+    // The noteworthy rejection stays visible.
+    await expect(canvas.getByText('Build #11')).toBeInTheDocument();
+    // Expanding the first run reveals its hidden builds + a "Hide" control.
+    const run = canvasElement.querySelector(
+      '.reqore-timeline-collapsed-run'
+    ) as HTMLElement;
+    await userEvent.click(run);
+    await expect(canvas.getByText('Build #14')).toBeInTheDocument();
+    await expect(canvas.getByText('Hide')).toBeInTheDocument();
+  },
 };

--- a/src/stories/Timeline/Timeline.stories.tsx
+++ b/src/stories/Timeline/Timeline.stories.tsx
@@ -866,7 +866,10 @@ export const CollapsedRange: Story = {
           intent: 'info',
         },
         {
+          // Expanded to show both states in one view: this run reveals its
+          // items + a "Hide" control; the later runs stay folded.
           label: '6 read-only builds',
+          defaultExpanded: true,
           collapsedItems: [
             { title: 'Build #17', timestamp: 'Jul 15', icon: 'TimeLine' },
             { title: 'Build #16', timestamp: 'Jul 15', icon: 'TimeLine' },
@@ -914,10 +917,12 @@ export const CollapsedRange: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    // Folded runs show their labels; the hidden builds aren't rendered.
-    await expect(canvas.getByText('6 read-only builds')).toBeInTheDocument();
+    // The first run is expanded (defaultExpanded): its items render inline
+    // with a "Hide" control.
+    await expect(canvas.getByText('Hide')).toBeInTheDocument();
+    await expect(canvas.getByText('Build #14')).toBeInTheDocument();
+    // The later runs stay folded — labels show, their hidden builds don't.
     await expect(canvas.getByText('2 read-only builds')).toBeInTheDocument();
-    await expect(canvas.queryByText('Build #14')).not.toBeInTheDocument();
     await expect(canvas.queryByText('Build #10')).not.toBeInTheDocument();
     // Noteworthy entries stay visible — including a normal entry sandwiched
     // between two collapsed runs.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2979,10 +2979,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
-"@qoretechnologies/qlip@^0.1.3-beta.20260622084321":
-  version "0.1.3-beta.20260622084321"
-  resolved "https://registry.yarnpkg.com/@qoretechnologies/qlip/-/qlip-0.1.3-beta.20260622084321.tgz#4e66b90e6eb84692795f28ad0469d9caeb58ed94"
-  integrity sha512-HGjwZKsIdx00GTg+drTsWWXtY6EX9u8E3HuFxW+KYH1vG2jsTfZwlpCJ2m7tB5AW72Nbt/A8aNjJ14Hph03LiQ==
+"@qoretechnologies/qlip@^0.1.3-beta.20260715110527":
+  version "0.1.3-beta.20260715110527"
+  resolved "https://registry.yarnpkg.com/@qoretechnologies/qlip/-/qlip-0.1.3-beta.20260715110527.tgz#4635453833e8cfa3306da2908dcfb2568460aba8"
+  integrity sha512-kzCw11KuX8kYmlSiGDkba/UlhIDefRSGoI9MFBuXULk75mAunbXZvf/i2w1cT05U4c6n8gq+6p61JtwJ/yn/MQ==
 
 "@radix-ui/number@1.1.1":
   version "1.1.1"


### PR DESCRIPTION
## What

`ReqoreTimeline` items can now include an **`IReqoreTimelineCollapsedRange`** alongside normal items:

```ts
{ collapsedItems: IReqoreTimelineItem[]; label?; icon?; iconColor?; defaultExpanded? }
```

A folded run renders as a single **muted vertical-3-dots marker** with an "N hidden" (or custom) label. Clicking it expands the items inline (GitHub-diff style) and shows a "Hide" control to re-fold. Purely visual — the caller decides which consecutive items to fold; the data model is untouched.

## Why

Long timelines bury the entries that matter (in our case: build rejections + commented builds) under runs of uneventful items. Folding those runs keeps the noteworthy ones visible.

## Notes

- The item renderer now takes an `onToggle` closure (was index-based `onToggleCollapse`) so items *inside* an expanded run carry their own collapse state. The existing per-item `collapsible` / `collapsedState` / `onCollapseChange` API is unchanged and fully backward compatible.
- New `onRangeToggle(index, isExpanded)` callback.
- Horizontal mode inlines ranges (no fold affordance — horizontal is minimal).

## Tests

- `__tests__/Timeline.test.tsx`: +2 tests (fold hides items until expanded; custom label / defaultExpanded / onRangeToggle). All 25 Timeline unit tests pass.
- New `CollapsedRange` story with a play test — passes in the browser project.
- `yarn test` (698 tests) + `yarn build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)