### PR TITLE
feat(Bubble): avatar + inline `title`/`detail` header for comment feeds

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -147,6 +147,27 @@ Every PR to `develop` MUST bump `package.json`'s `version` field before it merge
 - **Pattern:** ArgTypes for props, canvas controls, visual testing via Chromatic
 - **Command:** `yarn build-storybook` builds static site
 
+### Verifying a visual fix locally with Qlip (IMPORTANT)
+
+Before claiming a Qlip-flagged snapshot is fixed, **capture the story locally with Qlip and Read the PNG**. Text-based "the code says X" reasoning has repeatedly missed cases where the code change didn't actually reach the pixels (a prop that turned out to be a no-op, a rule beaten on specificity, a styled override the component ignored). The reviewer has ~870 snapshots per build to review; do not waste that time on "fixed" claims that didn't actually change the render.
+
+**How to capture one story locally without triggering upload:**
+
+```bash
+yarn test:stories src/stories/Tabs/Tabs.stories.tsx > /tmp/qlip-verify.log 2>&1
+```
+
+Then `Read` the specific PNG under `qlip/screenshots/<timestamp>/stories/auto/<Story__Id>.png` and inspect it as an image (Read supports PNGs). To prove the fix actually moved the pixels, compare the `md5` of that PNG against the same story in the previous capture directory — identical hashes mean the render did not change, whatever the diff says.
+
+**Rules of the road (violate these and you'll publish local screenshots to the shared review dashboard or mislead yourself with a stale capture):**
+
+- **NEVER set `QLIP_UPLOAD_TOKEN` locally.** `vitest.config.ts` attaches qlip's `upload` block only when that variable is present, and CI supplies it from the repository secret in `.github/workflows/tests.yml`. With it set, **every** `yarn test:stories` publishes a build the whole team then sees in review. This is not hypothetical: the token was hardcoded here until July 2026 and local runs posted four unwanted builds in a single session.
+- **Check for the upload line.** qlip prints `[qlip] uploaded build <id> … → https://qlip.qoretechnologies.com` when it publishes. If a local run prints that, the gate is broken — stop and fix it before continuing.
+- **NEVER run `yarn vitest run` with no `--project`** — it includes the storybook project and captures the whole ~870-snapshot suite, which will slow the machine to a crawl (and upload it, if the gate is broken). For unit tests use `yarn test` (`--project unit`), which captures nothing; for stories, one story file at a time.
+- **Delete the previous capture directory BEFORE you re-capture.** Qlip's file naming is `<StoryId>.png` — a re-capture overwrites, but a story that no longer exists (renamed, deleted, skipped) leaves its old PNG behind and will mislead you into reviewing a render that is no longer produced.
+
+Attempts that don't include a Qlip capture + PNG read are "I *think* I fixed it" — not "I fixed it". For visual reviews, the render is the source of truth.
+
 ## Code Patterns & Conventions
 
 ### Component Prop Interfaces

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,11 @@ jobs:
         run: yarn playwright install --with-deps chromium
       - name: Running Storybook interaction tests
         id: story_tests
+        # qlip publishes the visual build only when this is set, so uploads happen
+        # here and never from a developer's machine. Repository secret, not org —
+        # each project uploads under its own token.
+        env:
+          QLIP_UPLOAD_TOKEN: ${{ secrets.QLIP_UPLOAD_TOKEN }}
         run: yarn test:stories
       - name: Save release version to outputs
         id: save_release_version

--- a/__tests__/EntityRow.test.tsx
+++ b/__tests__/EntityRow.test.tsx
@@ -443,3 +443,46 @@ test('Renders <EntityRow /> with raised effect', () => {
 
   expect(document.querySelectorAll('.reqore-entity-row').length).toBe(1);
 });
+
+test('Renders an action with sub-actions as an overflow menu, not a button', () => {
+  const onRowClick = vi.fn();
+  const onShowInChat = vi.fn();
+
+  render(
+    <ReqoreUIProvider>
+      <ReqoreLayoutContent>
+        <ReqoreContent>
+          <ReqoreEntityRow
+            label='order-sync:1.0'
+            onClick={onRowClick}
+            actions={[
+              {
+                icon: 'More2Line',
+                actions: [
+                  { label: 'Show in chat', onClick: onShowInChat },
+                  { label: 'Hidden entry', show: false },
+                ],
+              },
+            ]}
+          />
+        </ReqoreContent>
+      </ReqoreLayoutContent>
+    </ReqoreUIProvider>
+  );
+
+  // closed menu: the items do not exist yet
+  expect(document.querySelectorAll('.reqore-menu-item').length).toBe(0);
+
+  fireEvent.click(document.querySelector('.reqore-entity-row-actions .reqore-button')!);
+
+  // `show: false` entries are dropped, so only the one item is offered
+  const items = document.querySelectorAll('.reqore-menu-item');
+  expect(items.length).toBe(1);
+  expect(items[0].textContent).toContain('Show in chat');
+
+  // opening the menu must not also trigger the (clickable) row
+  expect(onRowClick).not.toHaveBeenCalled();
+
+  fireEvent.click(items[0]);
+  expect(onShowInChat).toHaveBeenCalledTimes(1);
+});

--- a/__tests__/bubble.test.tsx
+++ b/__tests__/bubble.test.tsx
@@ -1,0 +1,113 @@
+import { render } from '@testing-library/react';
+import { ReqoreBubble, ReqoreContent, ReqoreLayoutContent, ReqoreUIProvider } from '../src';
+
+const renderBubbles = (children: React.ReactNode) =>
+  render(
+    <ReqoreUIProvider>
+      <ReqoreLayoutContent>
+        <ReqoreContent>{children}</ReqoreContent>
+      </ReqoreLayoutContent>
+    </ReqoreUIProvider>
+  );
+
+test('Renders <Bubble /> properly', () => {
+  renderBubbles(
+    <>
+      <ReqoreBubble align='left'>Hello</ReqoreBubble>
+      <ReqoreBubble align='right'>Hi</ReqoreBubble>
+    </>
+  );
+
+  expect(document.querySelectorAll('.reqore-bubble').length).toBe(2);
+});
+
+test('Renders <Bubble /> title and detail', () => {
+  renderBubbles(
+    <ReqoreBubble title='Ada Lovelace' detail='2h ago'>
+      Hello
+    </ReqoreBubble>
+  );
+
+  expect(document.querySelectorAll('.reqore-bubble-header').length).toBe(1);
+  expect(document.querySelector('.reqore-bubble-title').textContent).toBe('Ada Lovelace');
+  expect(document.querySelector('.reqore-bubble-detail').textContent).toBe('2h ago');
+});
+
+test('Renders no <Bubble /> header when neither title nor detail is given', () => {
+  renderBubbles(<ReqoreBubble>Hello</ReqoreBubble>);
+
+  expect(document.querySelector('.reqore-bubble-header')).toBeNull();
+});
+
+// Only an `avatar` introduces the row wrapper. Bubbles that predate the prop must
+// keep rendering bare, otherwise every existing transcript silently gains a level
+// of nesting and loses its own alignment.
+test('Renders <Bubble /> without an avatar row when no avatar is given', () => {
+  renderBubbles(<ReqoreBubble align='right'>Hello</ReqoreBubble>);
+
+  expect(document.querySelector('.reqore-bubble-avatar')).toBeNull();
+  expect(document.querySelector('.reqore-bubble-row')).toBeNull();
+  expect(document.querySelector('.reqore-bubble').closest('.reqore-bubble-row')).toBeNull();
+});
+
+// The avatar leads on the left and trails on the right, so it always sits on the
+// transcript's outer edge instead of between the two columns of text.
+test('Renders the <Bubble /> avatar on the side the bubble hugs', () => {
+  renderBubbles(
+    <>
+      <ReqoreBubble align='left' avatar={{ icon: 'User3Line' }}>
+        Hello
+      </ReqoreBubble>
+      <ReqoreBubble align='right' avatar={{ icon: 'CustomerService2Line' }}>
+        Hi
+      </ReqoreBubble>
+    </>
+  );
+
+  const rows = document.querySelectorAll('.reqore-bubble-row');
+
+  expect(rows.length).toBe(2);
+  expect(rows[0].firstElementChild.className).toContain('reqore-bubble-avatar');
+  expect(rows[0].lastElementChild.className).toContain('reqore-bubble');
+  expect(rows[1].firstElementChild.className).toContain('reqore-bubble');
+  expect(rows[1].lastElementChild.className).toContain('reqore-bubble-avatar');
+});
+
+// `radiusSize` opts both the bubble and its avatar onto the pronounced scale.
+// Without it they derive from `size`, so the two paths must differ visibly.
+test('Renders <Bubble /> corners from radiusSize when given, from size otherwise', () => {
+  const { unmount } = renderBubbles(
+    <ReqoreBubble avatar={{ icon: 'User3Line' }}>Hello</ReqoreBubble>
+  );
+  const bySize = {
+    bubble: getComputedStyle(document.querySelector('.reqore-bubble')).borderRadius,
+    avatar: getComputedStyle(document.querySelector('.reqore-bubble-avatar')).borderRadius,
+  };
+  unmount();
+
+  renderBubbles(
+    <ReqoreBubble avatar={{ icon: 'User3Line' }} radiusSize='massive'>
+      Hello
+    </ReqoreBubble>
+  );
+  const byRadiusSize = {
+    bubble: getComputedStyle(document.querySelector('.reqore-bubble')).borderRadius,
+    avatar: getComputedStyle(document.querySelector('.reqore-bubble-avatar')).borderRadius,
+  };
+
+  expect(bySize.bubble).toBe('15px');
+  expect(bySize.avatar).toBe('8px');
+  expect(byRadiusSize.bubble).toBe('70px');
+  expect(byRadiusSize.avatar).toBe('36px');
+});
+
+test('Renders an image <Bubble /> avatar', () => {
+  renderBubbles(
+    <ReqoreBubble avatar={{ image: 'https://example.com/logo.png' }}>Hello</ReqoreBubble>
+  );
+
+  expect(document.querySelectorAll('.reqore-bubble-avatar').length).toBe(1);
+  expect(document.querySelector('.reqore-bubble-avatar img').getAttribute('src')).toBe(
+    'https://example.com/logo.png'
+  );
+});

--- a/__tests__/bubble.test.tsx
+++ b/__tests__/bubble.test.tsx
@@ -1,5 +1,11 @@
 import { render } from '@testing-library/react';
-import { ReqoreBubble, ReqoreContent, ReqoreLayoutContent, ReqoreUIProvider } from '../src';
+import {
+  ReqoreBubble,
+  ReqoreBubbleGroup,
+  ReqoreContent,
+  ReqoreLayoutContent,
+  ReqoreUIProvider,
+} from '../src';
 
 const renderBubbles = (children: React.ReactNode) =>
   render(
@@ -21,22 +27,29 @@ test('Renders <Bubble /> properly', () => {
   expect(document.querySelectorAll('.reqore-bubble').length).toBe(2);
 });
 
-test('Renders <Bubble /> title and detail', () => {
-  renderBubbles(
-    <ReqoreBubble title='Ada Lovelace' detail='2h ago'>
-      Hello
-    </ReqoreBubble>
-  );
+test('Renders <Bubble /> label', () => {
+  renderBubbles(<ReqoreBubble label='Ada Lovelace'>Hello</ReqoreBubble>);
 
   expect(document.querySelectorAll('.reqore-bubble-header').length).toBe(1);
-  expect(document.querySelector('.reqore-bubble-title').textContent).toBe('Ada Lovelace');
-  expect(document.querySelector('.reqore-bubble-detail').textContent).toBe('2h ago');
+  expect(document.querySelector('.reqore-bubble-label').textContent).toBe('Ada Lovelace');
 });
 
-test('Renders no <Bubble /> header when neither title nor detail is given', () => {
+test('Renders no <Bubble /> header when no label is given', () => {
   renderBubbles(<ReqoreBubble>Hello</ReqoreBubble>);
 
   expect(document.querySelector('.reqore-bubble-header')).toBeNull();
+});
+
+// The time belongs under the bubble, not inside it — the way conversational UIs
+// print it. Inside the box it reads as part of the message.
+test('Renders the <Bubble /> timestamp below the bubble, not within it', () => {
+  renderBubbles(<ReqoreBubble timestamp='2h ago'>Hello</ReqoreBubble>);
+
+  const stamp = document.querySelector('.reqore-bubble-timestamp');
+
+  expect(stamp.textContent).toBe('2h ago');
+  expect(document.querySelector('.reqore-bubble').contains(stamp)).toBe(false);
+  expect(stamp.closest('.reqore-bubble-stack')).not.toBeNull();
 });
 
 // Only an `avatar` introduces the row wrapper. Bubbles that predate the prop must
@@ -66,11 +79,13 @@ test('Renders the <Bubble /> avatar on the side the bubble hugs', () => {
 
   const rows = document.querySelectorAll('.reqore-bubble-row');
 
+  // `classList.contains` rather than a substring match on className — the latter
+  // would happily pass on `reqore-bubble-stack` and prove nothing.
   expect(rows.length).toBe(2);
-  expect(rows[0].firstElementChild.className).toContain('reqore-bubble-avatar');
-  expect(rows[0].lastElementChild.className).toContain('reqore-bubble');
-  expect(rows[1].firstElementChild.className).toContain('reqore-bubble');
-  expect(rows[1].lastElementChild.className).toContain('reqore-bubble-avatar');
+  expect(rows[0].firstElementChild.classList.contains('reqore-bubble-avatar')).toBe(true);
+  expect(rows[0].lastElementChild.classList.contains('reqore-bubble')).toBe(true);
+  expect(rows[1].firstElementChild.classList.contains('reqore-bubble')).toBe(true);
+  expect(rows[1].lastElementChild.classList.contains('reqore-bubble-avatar')).toBe(true);
 });
 
 // `radiusSize` opts both the bubble and its avatar onto the pronounced scale.
@@ -99,6 +114,31 @@ test('Renders <Bubble /> corners from radiusSize when given, from size otherwise
   expect(bySize.avatar).toBe('8px');
   expect(byRadiusSize.bubble).toBe('70px');
   expect(byRadiusSize.avatar).toBe('36px');
+});
+
+// A run of same-side bubbles is one moment: only its last bubble prints a time,
+// so a burst of messages doesn't repeat the clock. Matches Qonsole's rule.
+test('Renders one timestamp per same-side run inside a <BubbleGroup />', () => {
+  renderBubbles(
+    <ReqoreBubbleGroup>
+      <ReqoreBubble align='right' timestamp='10:40 AM'>
+        Two messages…
+      </ReqoreBubble>
+      <ReqoreBubble align='right' timestamp='10:41 AM'>
+        …sent together
+      </ReqoreBubble>
+      <ReqoreBubble align='left' timestamp='10:42 AM'>
+        A reply
+      </ReqoreBubble>
+    </ReqoreBubbleGroup>
+  );
+
+  const stamps = [...document.querySelectorAll('.reqore-bubble-timestamp')].map(
+    (node) => node.textContent
+  );
+
+  // the right-side run collapses onto its last time; the lone left bubble keeps its own
+  expect(stamps).toEqual(['10:41 AM', '10:42 AM']);
 });
 
 test('Renders an image <Bubble /> avatar', () => {

--- a/__tests__/bubble.test.tsx
+++ b/__tests__/bubble.test.tsx
@@ -192,3 +192,20 @@ test('Renders an image <Bubble /> avatar', () => {
     'https://example.com/logo.png'
   );
 });
+
+// A circle is purely a style, so this asserts the radius against the default
+// squircle rather than in isolation: it fails both if `circle` stops rounding
+// and if the default silently becomes round.
+test('Renders a circular <Bubble /> avatar when `avatar.circle` is set', () => {
+  renderBubbles(
+    <>
+      <ReqoreBubble avatar={{ icon: 'User3Line' }}>Squircle</ReqoreBubble>
+      <ReqoreBubble avatar={{ icon: 'User3Line', circle: true }}>Circle</ReqoreBubble>
+    </>
+  );
+
+  const [squircle, circle] = document.querySelectorAll('.reqore-bubble-avatar');
+
+  expect(getComputedStyle(circle).borderRadius).toBe('9999px');
+  expect(getComputedStyle(squircle).borderRadius).not.toBe('9999px');
+});

--- a/__tests__/bubble.test.tsx
+++ b/__tests__/bubble.test.tsx
@@ -63,6 +63,26 @@ test('Renders <Bubble /> without an avatar row when no avatar is given', () => {
   expect(document.querySelector('.reqore-bubble').closest('.reqore-bubble-row')).toBeNull();
 });
 
+// A `maxWidth` bubble that gets a timestamp is wrapped in a stack. The cap has to
+// move onto that stack (with the bubble filling it) and the stack must be able to
+// shrink — otherwise the cap resolves against a content-sized wrapper and the
+// bubble runs off-screen at narrow widths instead of wrapping.
+test('Caps the timestamp stack, not the bubble, so a capped bubble can still wrap', () => {
+  renderBubbles(
+    <ReqoreBubble timestamp='2h ago' maxWidth='76%'>
+      Hello
+    </ReqoreBubble>
+  );
+
+  const stack = document.querySelector('.reqore-bubble-stack');
+  const bubble = stack.querySelector('.reqore-bubble');
+
+  expect(getComputedStyle(stack).maxWidth).toBe('76%');
+  expect(getComputedStyle(stack).minWidth).toBe('0px');
+  // the bubble no longer carries the cap itself — it fills the capped stack
+  expect(getComputedStyle(bubble).maxWidth).toBe('100%');
+});
+
 // The avatar leads on the left and trails on the right, so it always sits on the
 // transcript's outer edge instead of between the two columns of text.
 test('Renders the <Bubble /> avatar on the side the bubble hugs', () => {

--- a/__tests__/bubble.test.tsx
+++ b/__tests__/bubble.test.tsx
@@ -161,6 +161,27 @@ test('Renders one timestamp per same-side run inside a <BubbleGroup />', () => {
   expect(stamps).toEqual(['10:41 AM', '10:42 AM']);
 });
 
+// A timestamped bubble is capped, so it can't stretch to hug the group's edge —
+// it must align itself. Without this a right-aligned timestamped bubble drifts to
+// the middle while its bare siblings hug the right, breaking the transcript.
+test('Aligns a stacked (timestamped) bubble to its own side inside a group', () => {
+  renderBubbles(
+    <ReqoreBubbleGroup>
+      <ReqoreBubble align='right' timestamp='10:41 AM'>
+        outbound
+      </ReqoreBubble>
+      <ReqoreBubble align='left' timestamp='10:42 AM'>
+        inbound
+      </ReqoreBubble>
+    </ReqoreBubbleGroup>
+  );
+
+  const stacks = [...document.querySelectorAll('.reqore-bubble-stack')];
+
+  expect(getComputedStyle(stacks[0]).alignSelf).toBe('flex-end');
+  expect(getComputedStyle(stacks[1]).alignSelf).toBe('flex-start');
+});
+
 test('Renders an image <Bubble /> avatar', () => {
   renderBubbles(
     <ReqoreBubble avatar={{ image: 'https://example.com/logo.png' }}>Hello</ReqoreBubble>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.70.10",
+  "version": "0.70.11",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Bubble/index.tsx
+++ b/src/components/Bubble/index.tsx
@@ -332,8 +332,14 @@ export const ReqoreBubble = memo(
       // stable identity between renders. The stack carries the width cap (and can
       // shrink); the row just lets its children shrink past the aligned edge.
       const stackStyle = useMemo<CSSProperties>(
-        () => ({ minWidth: 0, maxWidth, ...(avatar ? undefined : style) }),
-        [maxWidth, avatar, style]
+        () => ({
+          minWidth: 0,
+          maxWidth,
+          ...(avatar
+            ? undefined
+            : { alignSelf: align === 'right' ? 'flex-end' : 'flex-start', ...style }),
+        }),
+        [maxWidth, avatar, align, style]
       );
       const rowStyle = useMemo<CSSProperties>(() => ({ minWidth: 0, ...style }), [style]);
 

--- a/src/components/Bubble/index.tsx
+++ b/src/components/Bubble/index.tsx
@@ -10,9 +10,20 @@ import {
 } from 'react';
 import { rgba } from 'polished';
 import styled, { css } from 'styled-components';
-import { PADDING_FROM_SIZE, RADIUS_FROM_SIZE, TEXT_FROM_SIZE, TSizes } from '../../constants/sizes';
+import {
+  BUBBLE_AVATAR_RADIUS_FROM_SIZE,
+  BUBBLE_RADIUS_FROM_RADIUS_SIZE,
+  BUBBLE_RADIUS_FROM_SIZE,
+  PADDING_FROM_SIZE,
+  RADIUS_FROM_SIZE,
+  resolveRadius,
+  SIZE_TO_PX,
+  TEXT_FROM_SIZE,
+  TSizes,
+} from '../../constants/sizes';
 import { IReqoreTheme } from '../../constants/theme';
 import { changeLightness, getReadableColor } from '../../helpers/colors';
+import { getOneLessSize } from '../../helpers/utils';
 import { useReqoreTheme } from '../../hooks/useTheme';
 import { RaisedElement } from '../../styles';
 import {
@@ -23,13 +34,23 @@ import {
   IWithReqoreMinimal,
   IWithReqoreSize,
 } from '../../types/global';
+import { IReqoreIconName } from '../../types/icons';
 import { IReqoreEffect, ReqoreEffect, StyledEffect } from '../Effect';
+import ReqoreIcon from '../Icon';
+import { ReqoreSpan } from '../Span';
 
 export type TReqoreBubbleAlign = 'left' | 'right';
 export type TReqoreBubbleGroupPosition = 'single' | 'first' | 'middle' | 'last';
 
+export interface IReqoreBubbleAvatar {
+  /** Icon glyph shown in the avatar. Ignored when `image` is set. */
+  icon?: IReqoreIconName;
+  /** Image shown in the avatar — a user photo, an app logo, … */
+  image?: string;
+}
+
 export interface IReqoreBubbleProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'color'>,
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'color' | 'title'>,
     IWithReqoreCustomTheme,
     IWithReqoreEffect,
     IWithReqoreSize,
@@ -43,6 +64,12 @@ export interface IReqoreBubbleProps
   /** Whether the bubble has rounded corners. Defaults to `true`. */
   rounded?: boolean;
   /**
+   * Opts the corners onto the pronounced `radiusSize` scale instead of deriving
+   * them from `size` — for both the bubble and its `avatar`. Ignored when
+   * `rounded={false}`.
+   */
+  radiusSize?: TSizes;
+  /**
    * Position within a run of same-side bubbles — controls which corners are
    * tightened so a group reads as one cluster. Usually set automatically by
    * `ReqoreBubbleGroup`. Defaults to `'single'`.
@@ -53,6 +80,24 @@ export interface IReqoreBubbleProps
    * Applied only on a borderless (`flat`), non-`intent` bubble.
    */
   raised?: boolean;
+  /**
+   * Avatar rendered *outside* the bubble, on the side the bubble hugs, tinted
+   * with the bubble's own colour and top-aligned with it. Give it an `icon` or
+   * an `image`. Adding one wraps the bubble in a row that takes over the
+   * alignment, so the avatar and the bubble travel to the aligned side together.
+   */
+  avatar?: IReqoreBubbleAvatar;
+  /** Bold lead-in on the bubble's first line — typically the author's name. */
+  title?: ReactNode;
+  /**
+   * Muted text beside `title` — typically a time. Unlike `timestamp`, which sits
+   * at the bubble's bottom-right, this reads inline with the author.
+   */
+  detail?: ReactNode;
+  /** Effect applied to `title` — merged over its bold default. */
+  titleEffect?: IReqoreEffect;
+  /** Effect applied to `detail` — merged over its muted default. */
+  detailEffect?: IReqoreEffect;
   /** Optional muted timestamp rendered at the bottom of the bubble. */
   timestamp?: ReactNode;
   /** Effect applied to the bubble's content (e.g. gradient or coloured text). */
@@ -71,12 +116,15 @@ interface IStyledBubbleProps {
   $minimal?: boolean;
   $flat?: boolean;
   $rounded?: boolean;
+  $radiusSize?: TSizes;
   $raised?: boolean;
   $clickable?: boolean;
   /** Whether the bubble carries an intent or customTheme — i.e. its own colour. */
   $coloured?: boolean;
   /** Whether an `effect` gradient paints the background (then no solid fill). */
   $hasGradient?: boolean;
+  /** Whether an avatar row wraps the bubble and owns the alignment. */
+  $inRow?: boolean;
 }
 
 // Border radius per group position: a run of same-side bubbles tightens the
@@ -106,8 +154,9 @@ export const StyledBubble = styled(StyledEffect)<IStyledBubbleProps>`
   display: block;
   width: fit-content;
   max-width: ${({ $maxWidth }) => $maxWidth};
-  margin-left: ${({ $align }) => ($align === 'right' ? 'auto' : 0)};
-  margin-right: ${({ $align }) => ($align === 'left' ? 'auto' : 0)};
+  /* Standalone, the bubble aligns itself; inside an avatar row the row does. */
+  margin-left: ${({ $align, $inRow }) => (!$inRow && $align === 'right' ? 'auto' : 0)};
+  margin-right: ${({ $align, $inRow }) => (!$inRow && $align === 'left' ? 'auto' : 0)};
   padding: ${({ $size }) =>
     `${Math.round(PADDING_FROM_SIZE[$size] * 1.3)}px ${Math.round(
       PADDING_FROM_SIZE[$size] * 1.85
@@ -117,10 +166,17 @@ export const StyledBubble = styled(StyledEffect)<IStyledBubbleProps>`
   word-break: break-word;
   cursor: ${({ $clickable }) => ($clickable ? 'pointer' : 'default')};
   transition: background-color 0.15s ease-out, filter 0.15s ease-out;
-  border-radius: ${({ $size, $rounded, $groupPosition, $align }) =>
+  border-radius: ${({ $size, $rounded, $radiusSize, $groupPosition, $align }) =>
     $rounded === false
       ? 0
-      : groupRadius($groupPosition, $align, RADIUS_FROM_SIZE[$size] * 3, RADIUS_FROM_SIZE[$size])};
+      : groupRadius(
+          $groupPosition,
+          $align,
+          resolveRadius($size, $radiusSize, BUBBLE_RADIUS_FROM_SIZE, BUBBLE_RADIUS_FROM_RADIUS_SIZE),
+          // the seam a cluster tightens to stays small whatever the outer curve —
+          // that contrast is what makes a run read as one bubble.
+          RADIUS_FROM_SIZE[$size]
+        )};
 
   ${({ theme, $minimal, $flat, $coloured, $hasGradient }) => {
     // A coloured bubble (intent / customTheme) tints its own colour; a plain one
@@ -165,14 +221,56 @@ const StyledTimestamp = styled.div<{ $size: TSizes }>`
   text-align: right;
 `;
 
+// Only rendered when there's an avatar: holds the avatar and the bubble side by
+// side and takes over the alignment, so both hug the same edge as one unit.
+export const StyledBubbleRow = styled.div<{ $align: TReqoreBubbleAlign; $size: TSizes }>`
+  display: flex;
+  align-items: flex-start;
+  gap: ${({ $size }) => PADDING_FROM_SIZE[$size]}px;
+  justify-content: ${({ $align }) => ($align === 'right' ? 'flex-end' : 'flex-start')};
+`;
+
+// The avatar echoes the bubble's own colour at the same strength a `minimal`
+// bubble uses, so the pair reads as one object whatever the bubble is themed to.
+export const StyledBubbleAvatar = styled.div<{
+  theme: IReqoreTheme;
+  $size: TSizes;
+  $radiusSize?: TSizes;
+  $coloured?: boolean;
+}>`
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  width: ${({ $size }) => SIZE_TO_PX[$size]}px;
+  height: ${({ $size }) => SIZE_TO_PX[$size]}px;
+  border-radius: ${({ $size, $radiusSize }) =>
+    resolveRadius($size, $radiusSize, BUBBLE_AVATAR_RADIUS_FROM_SIZE)}px;
+  background-color: ${({ theme, $coloured }) =>
+    $coloured ? rgba(theme.main, 0.16) : rgba(changeLightness(theme.main, 0.5), 0.1)};
+  color: ${({ theme }) => getReadableColor(theme)};
+`;
+
+const StyledBubbleHeader = styled.div<{ $size: TSizes }>`
+  display: flex;
+  align-items: baseline;
+  gap: ${({ $size }) => PADDING_FROM_SIZE[$size]}px;
+  margin-bottom: 4px;
+`;
+
 /**
  * A lightweight, themeable chat-style bubble. It sizes to its content (capped
  * by `maxWidth`) and hugs the left or right edge of its container via `align`.
  *
  * Like other Reqore surfaces it accepts `intent`, `customTheme`, `effect`
- * (including gradients), `flat`, `minimal` and `raised` — but carries none of
- * the avatar / title / action weight of `ReqoreComment`. Stack a column of
- * these (see `ReqoreBubbleGroup`) for a chat transcript.
+ * (including gradients), `flat`, `minimal` and `raised`. Stack a column of these
+ * (see `ReqoreBubbleGroup`) for a chat transcript.
+ *
+ * An optional `avatar` sits outside the bubble on the aligned side, and optional
+ * `title` / `detail` render as an inline header — enough for a comment feed
+ * without reaching for `ReqoreComment`, which is a full-width panel with room
+ * for actions rather than an aligned, content-width bubble.
  */
 export const ReqoreBubble = memo(
   forwardRef<HTMLDivElement, IReqoreBubbleProps>(
@@ -186,14 +284,21 @@ export const ReqoreBubble = memo(
         minimal,
         flat = true,
         rounded = true,
+        radiusSize,
         groupPosition = 'single',
         raised,
+        avatar,
+        title,
+        detail,
+        titleEffect,
+        detailEffect,
         timestamp,
         size = 'normal',
         effect,
         contentEffect,
         onClick,
         className,
+        style,
         children,
         ...rest
       },
@@ -201,11 +306,14 @@ export const ReqoreBubble = memo(
     ) => {
       const theme = useReqoreTheme('main', customTheme, intent, undefined, inheritCustomTheme);
       const showRaised = !!raised && flat !== false && !intent;
+      const coloured = !!intent || !!customTheme;
+      const isSet = (value: ReactNode) => value != null && value !== '';
+      const hasHeader = isSet(title) || isSet(detail);
 
       const bubbleEffect: IReqoreEffect | undefined =
         onClick || effect ? { interactive: !!onClick, ...effect } : undefined;
 
-      return (
+      const bubble = (
         <StyledBubble
           {...rest}
           as='div'
@@ -213,6 +321,10 @@ export const ReqoreBubble = memo(
           onClick={onClick}
           theme={theme}
           effect={bubbleEffect}
+          // Standalone, the bubble carries the caller's style; inside an avatar
+          // row the row carries it, so a group's spacing offsets the whole pair
+          // rather than sliding the bubble out of line with its avatar.
+          style={avatar ? undefined : style}
           $size={size}
           $align={align}
           $maxWidth={maxWidth}
@@ -220,17 +332,71 @@ export const ReqoreBubble = memo(
           $minimal={minimal}
           $flat={flat}
           $rounded={rounded}
+          $radiusSize={radiusSize}
           $raised={showRaised}
           $clickable={!!onClick}
-          $coloured={!!intent || !!customTheme}
+          $coloured={coloured}
           $hasGradient={!!effect?.gradient}
+          $inRow={!!avatar}
           className={`${className || ''} reqore-bubble`.trim()}
         >
+          {hasHeader && (
+            <StyledBubbleHeader $size={size} className='reqore-bubble-header'>
+              {isSet(title) && (
+                <ReqoreSpan
+                  className='reqore-bubble-title'
+                  size={size}
+                  effect={{ weight: 'bold', ...titleEffect }}
+                >
+                  {title}
+                </ReqoreSpan>
+              )}
+              {isSet(detail) && (
+                <ReqoreSpan
+                  className='reqore-bubble-detail'
+                  size={getOneLessSize(size)}
+                  effect={{ opacity: 0.5, ...detailEffect }}
+                >
+                  {detail}
+                </ReqoreSpan>
+              )}
+            </StyledBubbleHeader>
+          )}
           {contentEffect ? <ReqoreEffect effect={contentEffect}>{children}</ReqoreEffect> : children}
           {timestamp != null && timestamp !== '' && (
             <StyledTimestamp $size={size}>{timestamp}</StyledTimestamp>
           )}
         </StyledBubble>
+      );
+
+      if (!avatar) {
+        return bubble;
+      }
+
+      const avatarNode = (
+        <StyledBubbleAvatar
+          theme={theme}
+          $size={size}
+          $radiusSize={radiusSize}
+          $coloured={coloured}
+          className='reqore-bubble-avatar'
+        >
+          <ReqoreIcon
+            icon={avatar.icon}
+            image={avatar.image}
+            size={size}
+            // an image fills the avatar box; a glyph keeps its natural size, centred
+            wrapperSize={avatar.image ? `${SIZE_TO_PX[size]}px` : undefined}
+          />
+        </StyledBubbleAvatar>
+      );
+
+      return (
+        <StyledBubbleRow $align={align} $size={size} style={style} className='reqore-bubble-row'>
+          {align === 'left' && avatarNode}
+          {bubble}
+          {align === 'right' && avatarNode}
+        </StyledBubbleRow>
       );
     }
   )

--- a/src/components/Bubble/index.tsx
+++ b/src/components/Bubble/index.tsx
@@ -36,9 +36,14 @@ import {
   IWithReqoreSize,
 } from '../../types/global';
 import { IReqoreIconName } from '../../types/icons';
+import ReqoreControlGroup from '../ControlGroup';
 import { IReqoreEffect, ReqoreEffect, StyledEffect } from '../Effect';
 import ReqoreIcon from '../Icon';
 import { ReqoreSpan } from '../Span';
+
+// Hoisted so the memoised timestamp span keeps a stable `effect` identity.
+// 0.35 matches Qonsole's timestamp — fainter than the label, clearly secondary.
+const TIMESTAMP_EFFECT: IReqoreEffect = { opacity: 0.35 };
 
 export type TReqoreBubbleAlign = 'left' | 'right';
 export type TReqoreBubbleGroupPosition = 'single' | 'first' | 'middle' | 'last';
@@ -51,7 +56,7 @@ export interface IReqoreBubbleAvatar {
 }
 
 export interface IReqoreBubbleProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'color' | 'title'>,
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'color'>,
     IWithReqoreCustomTheme,
     IWithReqoreEffect,
     IWithReqoreSize,
@@ -89,17 +94,14 @@ export interface IReqoreBubbleProps
    */
   avatar?: IReqoreBubbleAvatar;
   /** Bold lead-in on the bubble's first line — typically the author's name. */
-  title?: ReactNode;
+  label?: ReactNode;
+  /** Effect applied to `label` — merged over its bold default. */
+  labelEffect?: IReqoreEffect;
   /**
-   * Muted text beside `title` — typically a time. Unlike `timestamp`, which sits
-   * at the bubble's bottom-right, this reads inline with the author.
+   * Muted timestamp rendered *below* the bubble, hugging the same side. Inside a
+   * `ReqoreBubbleGroup` only the last bubble of a same-side run renders it, so a
+   * cluster of messages reads as one moment rather than repeating the time.
    */
-  detail?: ReactNode;
-  /** Effect applied to `title` — merged over its bold default. */
-  titleEffect?: IReqoreEffect;
-  /** Effect applied to `detail` — merged over its muted default. */
-  detailEffect?: IReqoreEffect;
-  /** Optional muted timestamp rendered at the bottom of the bubble. */
   timestamp?: ReactNode;
   /** Effect applied to the bubble's content (e.g. gradient or coloured text). */
   contentEffect?: IReqoreEffect;
@@ -124,8 +126,8 @@ interface IStyledBubbleProps {
   $coloured?: boolean;
   /** Whether an `effect` gradient paints the background (then no solid fill). */
   $hasGradient?: boolean;
-  /** Whether an avatar row wraps the bubble and owns the alignment. */
-  $inRow?: boolean;
+  /** Whether a wrapper (avatar row / timestamp stack) owns the alignment. */
+  $wrapped?: boolean;
 }
 
 // Border radius per group position: a run of same-side bubbles tightens the
@@ -155,9 +157,9 @@ export const StyledBubble = styled(StyledEffect)<IStyledBubbleProps>`
   display: block;
   width: fit-content;
   max-width: ${({ $maxWidth }) => $maxWidth};
-  /* Standalone, the bubble aligns itself; inside an avatar row the row does. */
-  margin-left: ${({ $align, $inRow }) => (!$inRow && $align === 'right' ? 'auto' : 0)};
-  margin-right: ${({ $align, $inRow }) => (!$inRow && $align === 'left' ? 'auto' : 0)};
+  /* Standalone, the bubble aligns itself; once wrapped, the wrapper does. */
+  margin-left: ${({ $align, $wrapped }) => (!$wrapped && $align === 'right' ? 'auto' : 0)};
+  margin-right: ${({ $align, $wrapped }) => (!$wrapped && $align === 'left' ? 'auto' : 0)};
   padding: ${({ $size }) =>
     `${Math.round(PADDING_FROM_SIZE[$size] * 1.3)}px ${Math.round(
       PADDING_FROM_SIZE[$size] * 1.85
@@ -215,22 +217,6 @@ export const StyledBubble = styled(StyledEffect)<IStyledBubbleProps>`
     `}
 `;
 
-const StyledTimestamp = styled.div<{ $size: TSizes }>`
-  margin-top: 4px;
-  font-size: ${({ $size }) => Math.max(TEXT_FROM_SIZE[$size] - 4, 9)}px;
-  opacity: 0.55;
-  text-align: right;
-`;
-
-// Only rendered when there's an avatar: holds the avatar and the bubble side by
-// side and takes over the alignment, so both hug the same edge as one unit.
-export const StyledBubbleRow = styled.div<{ $align: TReqoreBubbleAlign; $size: TSizes }>`
-  display: flex;
-  align-items: flex-start;
-  gap: ${({ $size }) => PADDING_FROM_SIZE[$size]}px;
-  justify-content: ${({ $align }) => ($align === 'right' ? 'flex-end' : 'flex-start')};
-`;
-
 // The avatar echoes the bubble's own colour at the same strength a `minimal`
 // bubble uses, so the pair reads as one object whatever the bubble is themed to.
 export const StyledBubbleAvatar = styled.div<{
@@ -260,6 +246,15 @@ const StyledBubbleHeader = styled.div<{ $size: TSizes }>`
   margin-bottom: 4px;
 `;
 
+// The below-bubble timestamp, styled the way Qonsole treats its own: a small
+// inset so it doesn't sit hard against the bubble's edge, and non-selectable so
+// dragging across the transcript skips the clock. `padding`/`user-select` aren't
+// ReqoreSpan props, which is why this is a styled wrapper rather than props.
+const StyledBubbleTimestamp = styled(ReqoreSpan)`
+  padding: 2px 4px;
+  user-select: none;
+`;
+
 /**
  * A lightweight, themeable chat-style bubble. It sizes to its content (capped
  * by `maxWidth`) and hugs the left or right edge of its container via `align`.
@@ -268,10 +263,12 @@ const StyledBubbleHeader = styled.div<{ $size: TSizes }>`
  * (including gradients), `flat`, `minimal` and `raised`. Stack a column of these
  * (see `ReqoreBubbleGroup`) for a chat transcript.
  *
- * An optional `avatar` sits outside the bubble on the aligned side, and optional
- * `title` / `detail` render as an inline header — enough for a comment feed
- * without reaching for `ReqoreComment`, which is a full-width panel with room
- * for actions rather than an aligned, content-width bubble.
+ * An optional `avatar` sits outside the bubble on the aligned side and an optional
+ * `label` reads as a bold lead-in — enough for a comment feed without reaching for
+ * `ReqoreComment`, which is a full-width panel with room for actions rather than an
+ * aligned, content-width bubble. A `timestamp` prints below the bubble, and inside
+ * a `ReqoreBubbleGroup` only the last bubble of a same-side run shows one, so a
+ * cluster reads as a single moment.
  */
 export const ReqoreBubble = memo(
   forwardRef<HTMLDivElement, IReqoreBubbleProps>(
@@ -289,10 +286,8 @@ export const ReqoreBubble = memo(
         groupPosition = 'single',
         raised,
         avatar,
-        title,
-        detail,
-        titleEffect,
-        detailEffect,
+        label,
+        labelEffect,
         timestamp,
         size = 'normal',
         effect,
@@ -309,21 +304,23 @@ export const ReqoreBubble = memo(
       const showRaised = !!raised && flat !== false && !intent;
       const coloured = !!intent || !!customTheme;
       const isSet = (value: ReactNode) => value != null && value !== '';
-      const hasHeader = isSet(title) || isSet(detail);
+      // A run of same-side bubbles shares one time, printed under its last one —
+      // the way conversational UIs read a cluster as a single moment.
+      const showTimestamp =
+        isSet(timestamp) && (groupPosition === 'single' || groupPosition === 'last');
+      // Only the timestamp needs the bubble stacked under something; an avatar
+      // needs it beside one. Either way a wrapper owns the alignment from here.
+      const wrapped = !!avatar || showTimestamp;
 
       const bubbleEffect: IReqoreEffect | undefined =
         onClick || effect ? { interactive: !!onClick, ...effect } : undefined;
 
-      // The header's spans are memoised components, so their merged effect has to
-      // keep its identity between renders — a fresh literal would re-render them
-      // on every parent render. The caller's effect still wins on conflicts.
-      const resolvedTitleEffect = useMemo<IReqoreEffect>(
-        () => ({ weight: 'bold', ...titleEffect }),
-        [titleEffect]
-      );
-      const resolvedDetailEffect = useMemo<IReqoreEffect>(
-        () => ({ opacity: 0.5, ...detailEffect }),
-        [detailEffect]
+      // The label is a memoised component, so its merged effect has to keep its
+      // identity between renders — a fresh literal would re-render it on every
+      // parent render. The caller's effect still wins on conflicts.
+      const resolvedLabelEffect = useMemo<IReqoreEffect>(
+        () => ({ weight: 'bold', ...labelEffect }),
+        [labelEffect]
       );
 
       const bubble = (
@@ -334,10 +331,10 @@ export const ReqoreBubble = memo(
           onClick={onClick}
           theme={theme}
           effect={bubbleEffect}
-          // Standalone, the bubble carries the caller's style; inside an avatar
-          // row the row carries it, so a group's spacing offsets the whole pair
-          // rather than sliding the bubble out of line with its avatar.
-          style={avatar ? undefined : style}
+          // Standalone, the bubble carries the caller's style; once wrapped, the
+          // wrapper carries it, so a group's spacing offsets the whole unit
+          // rather than sliding the bubble out of line with its avatar or time.
+          style={wrapped ? undefined : style}
           $size={size}
           $align={align}
           $maxWidth={maxWidth}
@@ -350,43 +347,37 @@ export const ReqoreBubble = memo(
           $clickable={!!onClick}
           $coloured={coloured}
           $hasGradient={!!effect?.gradient}
-          $inRow={!!avatar}
+          $wrapped={wrapped}
           className={`${className || ''} reqore-bubble`.trim()}
         >
-          {hasHeader && (
+          {isSet(label) && (
             <StyledBubbleHeader $size={size} className='reqore-bubble-header'>
-              {isSet(title) && (
-                <ReqoreSpan
-                  className='reqore-bubble-title'
-                  size={size}
-                  effect={resolvedTitleEffect}
-                >
-                  {title}
-                </ReqoreSpan>
-              )}
-              {isSet(detail) && (
-                <ReqoreSpan
-                  className='reqore-bubble-detail'
-                  size={getOneLessSize(size)}
-                  effect={resolvedDetailEffect}
-                >
-                  {detail}
-                </ReqoreSpan>
-              )}
+              <ReqoreSpan className='reqore-bubble-label' size={size} effect={resolvedLabelEffect}>
+                {label}
+              </ReqoreSpan>
             </StyledBubbleHeader>
           )}
           {contentEffect ? <ReqoreEffect effect={contentEffect}>{children}</ReqoreEffect> : children}
-          {timestamp != null && timestamp !== '' && (
-            <StyledTimestamp $size={size}>{timestamp}</StyledTimestamp>
-          )}
         </StyledBubble>
       );
 
-      if (!avatar) {
+      const timestampNode = showTimestamp ? (
+        <StyledBubbleTimestamp
+          className='reqore-bubble-timestamp'
+          size={getOneLessSize(size)}
+          effect={TIMESTAMP_EFFECT}
+        >
+          {timestamp}
+        </StyledBubbleTimestamp>
+      ) : null;
+
+      // Nothing to hang off the bubble — render it bare, exactly as it did before
+      // `avatar` and the below-bubble timestamp existed.
+      if (!wrapped) {
         return bubble;
       }
 
-      const avatarNode = (
+      const avatarNode = avatar ? (
         <StyledBubbleAvatar
           theme={theme}
           $size={size}
@@ -402,14 +393,41 @@ export const ReqoreBubble = memo(
             wrapperSize={avatar.image ? `${SIZE_TO_PX[size]}px` : undefined}
           />
         </StyledBubbleAvatar>
+      ) : null;
+
+      // The time hangs off the bubble, not off the row — otherwise it lines up
+      // under the avatar instead of under the message it belongs to.
+      const stack = showTimestamp ? (
+        <ReqoreControlGroup
+          vertical
+          gapSize='tiny'
+          horizontalAlign={align === 'right' ? 'flex-end' : 'flex-start'}
+          style={avatar ? undefined : style}
+          className='reqore-bubble-stack'
+        >
+          {bubble}
+          {timestampNode}
+        </ReqoreControlGroup>
+      ) : (
+        bubble
       );
 
+      if (!avatar) {
+        return stack;
+      }
+
       return (
-        <StyledBubbleRow $align={align} $size={size} style={style} className='reqore-bubble-row'>
+        <ReqoreControlGroup
+          verticalAlign='flex-start'
+          gapSize={size}
+          horizontalAlign={align === 'right' ? 'flex-end' : 'flex-start'}
+          style={style}
+          className='reqore-bubble-row'
+        >
           {align === 'left' && avatarNode}
-          {bubble}
+          {stack}
           {align === 'right' && avatarNode}
-        </StyledBubbleRow>
+        </ReqoreControlGroup>
       );
     }
   )

--- a/src/components/Bubble/index.tsx
+++ b/src/components/Bubble/index.tsx
@@ -54,6 +54,11 @@ export interface IReqoreBubbleAvatar {
   icon?: IReqoreIconName;
   /** Image shown in the avatar — a user photo, an app logo, … */
   image?: string;
+  /**
+   * Render the avatar as a circle instead of the default squircle. Conventional
+   * for people — a photo or initials — where the squircle reads as an app tile.
+   */
+  circle?: boolean;
 }
 
 export interface IReqoreBubbleProps
@@ -229,6 +234,7 @@ export const StyledBubbleAvatar = styled.div<{
   $size: TSizes;
   $radiusSize?: TSizes;
   $coloured?: boolean;
+  $circle?: boolean;
 }>`
   flex: 0 0 auto;
   display: flex;
@@ -237,8 +243,10 @@ export const StyledBubbleAvatar = styled.div<{
   overflow: hidden;
   width: ${({ $size }) => SIZE_TO_PX[$size]}px;
   height: ${({ $size }) => SIZE_TO_PX[$size]}px;
-  border-radius: ${({ $size, $radiusSize }) =>
-    resolveRadius($size, $radiusSize, BUBBLE_AVATAR_RADIUS_FROM_SIZE)}px;
+  border-radius: ${({ $size, $radiusSize, $circle }) =>
+    $circle
+      ? '9999px'
+      : `${resolveRadius($size, $radiusSize, BUBBLE_AVATAR_RADIUS_FROM_SIZE)}px`};
   background-color: ${({ theme, $coloured }) =>
     $coloured ? rgba(theme.main, 0.16) : rgba(changeLightness(theme.main, 0.5), 0.1)};
   color: ${({ theme }) => getReadableColor(theme)};
@@ -404,6 +412,7 @@ export const ReqoreBubble = memo(
           $size={size}
           $radiusSize={radiusSize}
           $coloured={coloured}
+          $circle={avatar.circle}
           className='reqore-bubble-avatar'
         >
           <ReqoreIcon

--- a/src/components/Bubble/index.tsx
+++ b/src/components/Bubble/index.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   isValidElement,
   memo,
+  useMemo,
   type HTMLAttributes,
   type ReactElement,
   type ReactNode,
@@ -313,6 +314,18 @@ export const ReqoreBubble = memo(
       const bubbleEffect: IReqoreEffect | undefined =
         onClick || effect ? { interactive: !!onClick, ...effect } : undefined;
 
+      // The header's spans are memoised components, so their merged effect has to
+      // keep its identity between renders — a fresh literal would re-render them
+      // on every parent render. The caller's effect still wins on conflicts.
+      const resolvedTitleEffect = useMemo<IReqoreEffect>(
+        () => ({ weight: 'bold', ...titleEffect }),
+        [titleEffect]
+      );
+      const resolvedDetailEffect = useMemo<IReqoreEffect>(
+        () => ({ opacity: 0.5, ...detailEffect }),
+        [detailEffect]
+      );
+
       const bubble = (
         <StyledBubble
           {...rest}
@@ -346,7 +359,7 @@ export const ReqoreBubble = memo(
                 <ReqoreSpan
                   className='reqore-bubble-title'
                   size={size}
-                  effect={{ weight: 'bold', ...titleEffect }}
+                  effect={resolvedTitleEffect}
                 >
                   {title}
                 </ReqoreSpan>
@@ -355,7 +368,7 @@ export const ReqoreBubble = memo(
                 <ReqoreSpan
                   className='reqore-bubble-detail'
                   size={getOneLessSize(size)}
-                  effect={{ opacity: 0.5, ...detailEffect }}
+                  effect={resolvedDetailEffect}
                 >
                   {detail}
                 </ReqoreSpan>

--- a/src/components/Bubble/index.tsx
+++ b/src/components/Bubble/index.tsx
@@ -128,6 +128,8 @@ interface IStyledBubbleProps {
   $hasGradient?: boolean;
   /** Whether a wrapper (avatar row / timestamp stack) owns the alignment. */
   $wrapped?: boolean;
+  /** Whether a timestamp stack wraps the bubble and carries the width cap. */
+  $stacked?: boolean;
 }
 
 // Border radius per group position: a run of same-side bubbles tightens the
@@ -156,7 +158,9 @@ function groupRadius(
 export const StyledBubble = styled(StyledEffect)<IStyledBubbleProps>`
   display: block;
   width: fit-content;
-  max-width: ${({ $maxWidth }) => $maxWidth};
+  /* Inside a timestamp stack the wrapper carries the cap and the bubble fills it;
+     standalone (or directly in the avatar row) the bubble carries it. */
+  max-width: ${({ $stacked, $maxWidth }) => ($stacked ? '100%' : $maxWidth)};
   /* Standalone, the bubble aligns itself; once wrapped, the wrapper does. */
   margin-left: ${({ $align, $wrapped }) => (!$wrapped && $align === 'right' ? 'auto' : 0)};
   margin-right: ${({ $align, $wrapped }) => (!$wrapped && $align === 'left' ? 'auto' : 0)};
@@ -348,6 +352,7 @@ export const ReqoreBubble = memo(
           $coloured={coloured}
           $hasGradient={!!effect?.gradient}
           $wrapped={wrapped}
+          $stacked={showTimestamp}
           className={`${className || ''} reqore-bubble`.trim()}
         >
           {isSet(label) && (
@@ -396,13 +401,15 @@ export const ReqoreBubble = memo(
       ) : null;
 
       // The time hangs off the bubble, not off the row — otherwise it lines up
-      // under the avatar instead of under the message it belongs to.
+      // under the avatar instead of under the message it belongs to. The stack
+      // carries the width cap (the bubble fills it at 100%) and can shrink
+      // (`min-width: 0`), so a capped bubble still wraps rather than overflowing.
       const stack = showTimestamp ? (
         <ReqoreControlGroup
           vertical
           gapSize='tiny'
           horizontalAlign={align === 'right' ? 'flex-end' : 'flex-start'}
-          style={avatar ? undefined : style}
+          style={{ minWidth: 0, maxWidth, ...(avatar ? undefined : style) }}
           className='reqore-bubble-stack'
         >
           {bubble}
@@ -420,8 +427,9 @@ export const ReqoreBubble = memo(
         <ReqoreControlGroup
           verticalAlign='flex-start'
           gapSize={size}
+          // let the stack/bubble shrink instead of pushing off the aligned edge
+          style={{ minWidth: 0, ...style }}
           horizontalAlign={align === 'right' ? 'flex-end' : 'flex-start'}
-          style={style}
           className='reqore-bubble-row'
         >
           {align === 'left' && avatarNode}

--- a/src/components/Bubble/index.tsx
+++ b/src/components/Bubble/index.tsx
@@ -5,6 +5,7 @@ import {
   isValidElement,
   memo,
   useMemo,
+  type CSSProperties,
   type HTMLAttributes,
   type ReactElement,
   type ReactNode,
@@ -327,6 +328,15 @@ export const ReqoreBubble = memo(
         [labelEffect]
       );
 
+      // The wrappers are memoised ControlGroups, so their `style` has to keep a
+      // stable identity between renders. The stack carries the width cap (and can
+      // shrink); the row just lets its children shrink past the aligned edge.
+      const stackStyle = useMemo<CSSProperties>(
+        () => ({ minWidth: 0, maxWidth, ...(avatar ? undefined : style) }),
+        [maxWidth, avatar, style]
+      );
+      const rowStyle = useMemo<CSSProperties>(() => ({ minWidth: 0, ...style }), [style]);
+
       const bubble = (
         <StyledBubble
           {...rest}
@@ -409,7 +419,7 @@ export const ReqoreBubble = memo(
           vertical
           gapSize='tiny'
           horizontalAlign={align === 'right' ? 'flex-end' : 'flex-start'}
-          style={{ minWidth: 0, maxWidth, ...(avatar ? undefined : style) }}
+          style={stackStyle}
           className='reqore-bubble-stack'
         >
           {bubble}
@@ -428,7 +438,7 @@ export const ReqoreBubble = memo(
           verticalAlign='flex-start'
           gapSize={size}
           // let the stack/bubble shrink instead of pushing off the aligned edge
-          style={{ minWidth: 0, ...style }}
+          style={rowStyle}
           horizontalAlign={align === 'right' ? 'flex-end' : 'flex-start'}
           className='reqore-bubble-row'
         >

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -439,16 +439,37 @@ export const StyledButton = styled(StyledEffect)<IReqoreButtonStyle>`
         `
       : undefined};
 
-  ${({ active, flat, theme, color, effect }: IReqoreButtonStyle) => {
+  ${({ active, flat, transparent, theme, color, effect }: IReqoreButtonStyle) => {
     if (active) {
+      /*
+       * A transparent button stays transparent when active.
+       *
+       * The active state paints a fill and derives its label colour FROM that fill, so
+       * on a transparent button it produced an opaque background the consumer never
+       * asked for — and, for anyone suppressing that background in CSS, a label colour
+       * computed for a background that is no longer there. With an intent the phantom
+       * fill is light, so the label resolves to near-black and disappears against a
+       * dark surface.
+       *
+       * Deliberately NOT extended to `minimal`: a minimal button going solid when
+       * active is long-standing, intended emphasis (active menu items, table headers,
+       * segmented controls all rely on it). Only `transparent` — which is an explicit
+       * request for no background — is honoured here.
+       */
+      const solidBackground = changeLightness(getButtonMainColor(theme, color, effect), 0.1);
+
       return css`
         cursor: pointer;
-        background-color: ${changeLightness(getButtonMainColor(theme, color, effect), 0.1)};
-        color: ${getReadableColor(
-          { main: changeLightness(getButtonMainColor(theme, color, effect), 0.1) },
-          undefined,
-          undefined
-        )};
+        background-color: ${transparent ? 'transparent' : solidBackground};
+        color: ${transparent
+          ? isAchromatic(getButtonMainColor(theme, color, effect))
+            ? /* undimmed, unlike the resting state: an active label should read as the
+                 brightest thing in the group, not the same as its neighbours */
+              getReadableColorFrom(theme.originalMain)
+            : /* a tint of the intent — legible on the page's own surface, and it echoes
+                 whatever marks the active item */
+              saturate(1, tint(0.8, getButtonMainColor(theme, color, effect)))
+          : getReadableColor({ main: solidBackground }, undefined, undefined)};
         border-color: ${flat
           ? undefined
           : changeLightness(getButtonMainColor(theme, color, effect), 0.175)};

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -439,37 +439,16 @@ export const StyledButton = styled(StyledEffect)<IReqoreButtonStyle>`
         `
       : undefined};
 
-  ${({ active, flat, transparent, theme, color, effect }: IReqoreButtonStyle) => {
+  ${({ active, flat, theme, color, effect }: IReqoreButtonStyle) => {
     if (active) {
-      /*
-       * A transparent button stays transparent when active.
-       *
-       * The active state paints a fill and derives its label colour FROM that fill, so
-       * on a transparent button it produced an opaque background the consumer never
-       * asked for — and, for anyone suppressing that background in CSS, a label colour
-       * computed for a background that is no longer there. With an intent the phantom
-       * fill is light, so the label resolves to near-black and disappears against a
-       * dark surface.
-       *
-       * Deliberately NOT extended to `minimal`: a minimal button going solid when
-       * active is long-standing, intended emphasis (active menu items, table headers,
-       * segmented controls all rely on it). Only `transparent` — which is an explicit
-       * request for no background — is honoured here.
-       */
-      const solidBackground = changeLightness(getButtonMainColor(theme, color, effect), 0.1);
-
       return css`
         cursor: pointer;
-        background-color: ${transparent ? 'transparent' : solidBackground};
-        color: ${transparent
-          ? isAchromatic(getButtonMainColor(theme, color, effect))
-            ? /* undimmed, unlike the resting state: an active label should read as the
-                 brightest thing in the group, not the same as its neighbours */
-              getReadableColorFrom(theme.originalMain)
-            : /* a tint of the intent — legible on the page's own surface, and it echoes
-                 whatever marks the active item */
-              saturate(1, tint(0.8, getButtonMainColor(theme, color, effect)))
-          : getReadableColor({ main: solidBackground }, undefined, undefined)};
+        background-color: ${changeLightness(getButtonMainColor(theme, color, effect), 0.1)};
+        color: ${getReadableColor(
+          { main: changeLightness(getButtonMainColor(theme, color, effect), 0.1) },
+          undefined,
+          undefined
+        )};
         border-color: ${flat
           ? undefined
           : changeLightness(getButtonMainColor(theme, color, effect), 0.175)};

--- a/src/components/DescriptionList/index.tsx
+++ b/src/components/DescriptionList/index.tsx
@@ -1,7 +1,12 @@
 import { rgba } from 'polished';
 import { forwardRef, memo, ReactNode, useMemo } from 'react';
 import styled, { css } from 'styled-components';
-import { TSizes } from '../../constants/sizes';
+import {
+  CONTROL_HORIZONTAL_PADDING_FROM_SIZE,
+  PADDING_FROM_SIZE,
+  SIZE_TO_PX,
+  TSizes,
+} from '../../constants/sizes';
 import { IReqoreTheme, TReqoreIntent } from '../../constants/theme';
 import { changeLightness, getMainBackgroundColor } from '../../helpers/colors';
 import { getOneHigherSize, getOneLessSize } from '../../helpers/utils';
@@ -56,6 +61,14 @@ export interface IReqoreDescriptionListRow {
   uppercaseLabel?: boolean;
 }
 
+interface IStyledContentProps {
+  $controlSize?: TSizes;
+}
+
+/** The vertical padding rows have always had. Kept as the default so existing lists
+ *  are untouched — `rowPadding` opts into the size scale instead. */
+const DEFAULT_ROW_PADDING = 10;
+
 export interface IReqoreDescriptionListProps extends Omit<IReqorePanelProps, 'children'> {
   /** Rows to render top-to-bottom. */
   items: IReqoreDescriptionListRow[];
@@ -82,6 +95,36 @@ export interface IReqoreDescriptionListProps extends Omit<IReqorePanelProps, 'ch
    * to the wrapping `ReqorePanel`. Defaults to `'normal'`.
    */
   size?: TSizes;
+  /**
+   * Size the content column for CONTROLS rather than for text.
+   *
+   * Every row then reserves a control of this size's height, and any content that
+   * isn't itself a control is inset by that size's horizontal padding — so a list
+   * mixing plain values with buttons, dropdowns and tags keeps one left edge and one
+   * row rhythm. Omitted (the default) leaves each row sized by its own content, which
+   * is what an all-text list wants.
+   */
+  contentSize?: TSizes;
+  /**
+   * Size the LABEL column's text independently of the content.
+   *
+   * Labels are reference furniture — a list can want them quieter and smaller than
+   * the values they name, and a fixed `labelWidth` has to fit them. Defaults to
+   * `size`, so a list that doesn't ask keeps both columns at one scale.
+   *
+   * Named `labelTextSize`, not `labelSize`: the panel this extends already has a
+   * `labelSize`, and it means the heading LEVEL of the panel's own label. Different
+   * thing, and worth keeping.
+   */
+  labelTextSize?: TSizes;
+  /**
+   * Vertical padding on each row, from the size scale — the list's density.
+   *
+   * Omitted, rows keep the padding they have always had. Set it when the list has to
+   * sit on a rhythm something else is measured against (a tab strip below it, a
+   * sibling list), where the row height has to be predictable rather than comfortable.
+   */
+  rowPadding?: TSizes;
 }
 
 interface IStyledRowProps {
@@ -109,13 +152,20 @@ const StyledRow = styled.div<IStyledRowProps>`
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 0;
+  padding: ${({ $rowPadding }) => $rowPadding}px 0;
 
+  /*
+   * The separator is drawn, not laid out. As a border it added its 1px to the row's
+   * box, so every row except the last stood 1px taller and a list whose rows should
+   * read as one rhythm was measurably ragged — which matters as soon as anything is
+   * aligned to a row's height. An inset shadow paints the same hairline without
+   * participating in layout.
+   */
   ${({ $isLast, $separatorOpacity, theme }) =>
     !$isLast &&
     $separatorOpacity > 0 &&
     css`
-      border-bottom: 1px solid
+      box-shadow: inset 0 -1px 0
         ${rgba(changeLightness(getMainBackgroundColor(theme), 0.16), $separatorOpacity)};
     `}
 `;
@@ -152,13 +202,41 @@ const StyledLabel = styled.div<IStyledLabelProps>`
   }
 `;
 
-const StyledContent = styled.div`
+const StyledContent = styled.div<IStyledContentProps>`
   flex: 1 1 auto;
   min-width: 0;
   display: flex;
   align-items: center;
   gap: 8px;
   font-variant-numeric: tabular-nums;
+
+  ${({ $controlSize }) =>
+    $controlSize &&
+    css`
+      /*
+       * Reserve a control's height on every row, whether or not the row holds one:
+       * a row of buttons is 32px while a row of text is 14-18px, so left to their
+       * content the rows differ by half their height and the list reads as ragged
+       * rather than tabular.
+       */
+      min-height: ${SIZE_TO_PX[$controlSize]}px;
+
+      /*
+       * And give bare content the inset a control applies to its own. A control
+       * insets its content by its horizontal padding, so a button's label sits ~12px
+       * into the column while plain text starts at 0, and the two columns of values
+       * never line up. Handing the inset to whatever ISN'T a control means a new
+       * plain value cannot be added misaligned.
+       *
+       * Both shapes of control are excluded: Reqore renders the button AS the value
+       * (ReqoreButton, ReqoreDropdown with a string label) or nests one inside a
+       * wrapper, and matching only the nested case leaves the root-button rows
+       * picking up this inset on top of their own.
+       */
+      > *:not(.reqore-button):not(:has(.reqore-button)) {
+        padding-left: ${CONTROL_HORIZONTAL_PADDING_FROM_SIZE[$controlSize]}px;
+      }
+    `}
 `;
 
 /**
@@ -211,6 +289,9 @@ export const ReqoreDescriptionList = memo(
         uppercaseLabels = true,
         separatorOpacity = 0.06,
         size = 'normal',
+        contentSize,
+        labelTextSize,
+        rowPadding,
         padded,
         className,
         ...panelRest
@@ -226,6 +307,8 @@ export const ReqoreDescriptionList = memo(
       // gutter so the label column stays vertically aligned across
       // rows with and without an intent.
       const anyRowHasIntent = useMemo(() => items.some((row) => Boolean(row.intent)), [items]);
+      const resolvedRowPadding = rowPadding ? PADDING_FROM_SIZE[rowPadding] : DEFAULT_ROW_PADDING;
+      const resolvedLabelSize = labelTextSize ?? size;
       return (
         <ReqorePanel
           {...panelRest}
@@ -246,6 +329,7 @@ export const ReqoreDescriptionList = memo(
                   key={row.key}
                   $separatorOpacity={separatorOpacity}
                   $isLast={isLast}
+                  $rowPadding={resolvedRowPadding}
                   className='reqore-description-list-row'
                   data-key={row.key}
                 >
@@ -271,12 +355,15 @@ export const ReqoreDescriptionList = memo(
                           ) : null}
                         </StyledIconSlot>
                       ) : null}
-                      <ReqoreP size={size} intent={row.labelIntent}>
+                      <ReqoreP size={resolvedLabelSize} intent={row.labelIntent}>
                         {row.label}
                       </ReqoreP>
                     </StyledLabel>
                   ) : null}
-                  <StyledContent className='reqore-description-list-content'>
+                  <StyledContent
+                    $controlSize={contentSize}
+                    className='reqore-description-list-content'
+                  >
                     {typeof row.content === 'string' || typeof row.content === 'number' ? (
                       <ReqoreP size={size} intent={row.contentIntent}>
                         {row.content}

--- a/src/components/EntityRow/index.tsx
+++ b/src/components/EntityRow/index.tsx
@@ -43,6 +43,19 @@ export interface IReqoreEntityRowAction extends Omit<IReqoreButtonProps, 'childr
   actionsProps?: IReqoreDropdownProps;
 }
 
+/**
+ * Opening a row's overflow menu must not also fire the row underneath it.
+ *
+ * Defined at module scope rather than inline: `ReqoreDropdown` is memoised, and a
+ * fresh arrow on every render is a new prop identity that defeats the memo. This
+ * handler closes over nothing, so one shared instance is all that is ever needed —
+ * `useCallback` would still allocate one per row.
+ */
+const stopRowClick = (event: React.MouseEvent<HTMLElement>) => event.stopPropagation();
+
+/** Same reasoning: a stable predicate instead of a new closure per render. */
+const isSubActionShown = ({ show }: IReqorePanelSubAction) => show !== false;
+
 export interface IReqoreEntityRowProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'>,
     IReqoreDisabled,
@@ -414,8 +427,8 @@ const ReqoreEntityRow = memo(
                     intent={action.intent ?? intent}
                     {...action}
                     {...actionsProps}
-                    items={subActions.filter(({ show }) => show !== false)}
-                    onClick={(event: React.MouseEvent<HTMLElement>) => event.stopPropagation()}
+                    items={subActions.filter(isSubActionShown)}
+                    onClick={stopRowClick}
                   />
                 ) : (
                   <ReqoreButton key={idx} size={size} intent={action.intent ?? intent} {...action}>

--- a/src/components/EntityRow/index.tsx
+++ b/src/components/EntityRow/index.tsx
@@ -20,8 +20,10 @@ import {
 import { IReqoreIconName } from '../../types/icons';
 import ReqoreButton, { ButtonBadge, IReqoreButtonProps, TReqoreBadge } from '../Button';
 import ReqoreControlGroup from '../ControlGroup';
+import ReqoreDropdown, { IReqoreDropdownProps } from '../Dropdown';
 import { IReqoreEffect, StyledEffect, TReqoreEffectColor } from '../Effect';
 import ReqoreIcon, { IReqoreIconProps } from '../Icon';
+import { IReqorePanelSubAction } from '../Panel';
 import { ReqoreP } from '../Paragraph';
 import { ReqoreSpan } from '../Span';
 import { ReqoreTooltipComponent } from '../TooltipComponent';
@@ -29,6 +31,16 @@ import { ReqoreTooltipComponent } from '../TooltipComponent';
 export interface IReqoreEntityRowAction extends Omit<IReqoreButtonProps, 'children'> {
   /** Visible button label. */
   label?: string;
+  /**
+   * Turns this action into an overflow menu instead of a plain button — the row
+   * equivalent of `IReqorePanelAction.actions`, and named to match it.
+   *
+   * Typical use is a "three dots" menu: `{ icon: 'More2Line', actions: [...] }`.
+   * Entries with `show: false` are dropped.
+   */
+  actions?: IReqorePanelSubAction[];
+  /** Extra props for the dropdown rendered when `actions` is set. */
+  actionsProps?: IReqoreDropdownProps;
 }
 
 export interface IReqoreEntityRowProps
@@ -389,16 +401,28 @@ const ReqoreEntityRow = memo(
           </StyledBody>
           {actions && actions.length > 0 && (
             <ReqoreControlGroup gapSize='small' className='reqore-entity-row-actions'>
-              {actions.map((action, idx) => (
-                <ReqoreButton
-                  key={idx}
-                  size={size}
-                  intent={action.intent ?? intent}
-                  {...action}
-                >
-                  {action.label}
-                </ReqoreButton>
-              ))}
+              {actions.map(({ actions: subActions, actionsProps, ...action }, idx) =>
+                subActions?.length ? (
+                  // An action carrying sub-actions is a menu, not a button — same
+                  // contract as ReqorePanel. The click is stopped here because the row
+                  // itself is commonly clickable: opening the menu must not also
+                  // trigger the row.
+                  <ReqoreDropdown
+                    key={idx}
+                    fixed
+                    size={size}
+                    intent={action.intent ?? intent}
+                    {...action}
+                    {...actionsProps}
+                    items={subActions.filter(({ show }) => show !== false)}
+                    onClick={(event: React.MouseEvent<HTMLElement>) => event.stopPropagation()}
+                  />
+                ) : (
+                  <ReqoreButton key={idx} size={size} intent={action.intent ?? intent} {...action}>
+                    {action.label}
+                  </ReqoreButton>
+                )
+              )}
             </ReqoreControlGroup>
           )}
         </ReqoreTooltipComponent>

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -12,6 +12,8 @@ import { IReqorePopoverProps } from '../Popover';
 import { TReqoreTabsContentPadding } from './content';
 import ReqoreTabsList from './list';
 
+export type TReqoreTabsActiveMarker = 'fill' | 'line';
+
 export interface IReqoreTabsListItem extends Omit<IReqoreButtonProps, 'id'> {
   label?: string | number;
   as?: any;
@@ -34,6 +36,13 @@ export interface IReqoreTabsProps extends IReqoreComponent, React.HTMLAttributes
   fillParent?: boolean;
   vertical?: boolean;
   activeTabIntent?: TReqoreIntent;
+  /**
+   * How the active tab is marked. `fill` (the default) tints the whole tab, the
+   * way Reqore tabs have always looked. `line` leaves the tab transparent and
+   * draws a bar along the list's edge instead — the quieter "underline" tab
+   * treatment, for dense surfaces where a filled tab would shout.
+   */
+  activeTabMarker?: TReqoreTabsActiveMarker;
   padded?: boolean;
   tabsPadding?: TReqoreTabsContentPadding;
   wrapTabNames?: boolean;
@@ -83,6 +92,7 @@ const ReqoreTabs = ({
   _testWidth,
   vertical,
   activeTabIntent,
+  activeTabMarker = 'fill',
   flat = true,
   size = 'normal',
   width,
@@ -142,6 +152,7 @@ const ReqoreTabs = ({
           activeTab={_activeTab}
           wrapTabNames={wrapTabNames}
           activeTabIntent={activeTabIntent}
+          activeTabMarker={activeTabMarker}
           customTheme={customTheme}
           intent={intent}
           onTabChange={handleTabChange}

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -7,6 +7,7 @@ import { IReqoreCustomTheme, TReqoreIntent } from '../../constants/theme';
 import { IReqoreComponent, IWithReqoreLoading } from '../../types/global';
 import { IReqoreIconName } from '../../types/icons';
 import { IReqoreButtonProps } from '../Button';
+import { TReqoreEffectColor } from '../Effect';
 import { IReqoreMenuProps } from '../Menu';
 import { IReqorePopoverProps } from '../Popover';
 import { TReqoreTabsContentPadding } from './content';
@@ -43,6 +44,12 @@ export interface IReqoreTabsProps extends IReqoreComponent, React.HTMLAttributes
    * treatment, for dense surfaces where a filled tab would shout.
    */
   activeTabMarker?: TReqoreTabsActiveMarker;
+  /**
+   * Colour of the `line` marker. Defaults to the active intent's colour, and
+   * failing that the tab's own text colour — set this when the bar should carry
+   * an accent the label doesn't, which is the usual underline-tab treatment.
+   */
+  activeTabMarkerColor?: TReqoreEffectColor;
   padded?: boolean;
   tabsPadding?: TReqoreTabsContentPadding;
   wrapTabNames?: boolean;
@@ -93,6 +100,7 @@ const ReqoreTabs = ({
   vertical,
   activeTabIntent,
   activeTabMarker = 'fill',
+  activeTabMarkerColor,
   flat = true,
   size = 'normal',
   width,
@@ -153,6 +161,7 @@ const ReqoreTabs = ({
           wrapTabNames={wrapTabNames}
           activeTabIntent={activeTabIntent}
           activeTabMarker={activeTabMarker}
+          activeTabMarkerColor={activeTabMarkerColor}
           customTheme={customTheme}
           intent={intent}
           onTabChange={handleTabChange}

--- a/src/components/Tabs/item.tsx
+++ b/src/components/Tabs/item.tsx
@@ -2,7 +2,7 @@ import { omit } from 'lodash';
 import { forwardRef, memo, useState, useTransition } from 'react';
 import { useUnmount, useUpdateEffect } from 'react-use';
 import styled, { css } from 'styled-components';
-import { IReqoreTabsListItem } from '.';
+import { IReqoreTabsListItem, TReqoreTabsActiveMarker } from '.';
 import { TSizes } from '../../constants/sizes';
 import { IReqoreCustomTheme, IReqoreTheme } from '../../constants/theme';
 import { useCombinedRefs } from '../../hooks/useCombinedRefs';
@@ -14,6 +14,8 @@ import ReqoreControlGroup from '../ControlGroup';
 export interface IReqoreTabListItemProps extends IReqoreTabsListItem, IWithReqoreFlat {
   active?: boolean;
   vertical?: boolean;
+  /** How the active tab is marked — see `IReqoreTabsProps.activeTabMarker`. */
+  activeTabMarker?: TReqoreTabsActiveMarker;
   onCloseClick?: any;
   customTheme?: IReqoreCustomTheme;
   size?: TSizes;
@@ -31,7 +33,16 @@ export interface IReqoreTabListItemStyle extends IReqoreTabListItemProps {
 }
 
 export const StyledTabListItem = styled.div<IReqoreTabListItemStyle>`
-  ${({ disabled, vertical, fill, fixed, padded }: IReqoreTabListItemStyle) => {
+  ${({
+    disabled,
+    vertical,
+    fill,
+    fixed,
+    padded,
+    active,
+    activeTabMarker,
+    activeColor,
+  }: IReqoreTabListItemStyle) => {
     return css`
       display: flex;
       flex-shrink: 0;
@@ -94,6 +105,22 @@ export const StyledTabListItem = styled.div<IReqoreTabListItemStyle>`
           opacity: 0.5;
         }
       `}
+
+      ${activeTabMarker === 'line' &&
+      css`
+        /* The tab itself stays transparent — the active one is marked by a bar
+           along the list's edge instead of a filled background. */
+        ${StyledButton} {
+          background-color: transparent !important;
+          border-radius: 0 !important;
+        }
+
+        ${active &&
+        css`
+          box-shadow: inset ${vertical ? '-2px 0 0 0' : '0 -2px 0 0'}
+            ${activeColor || 'currentColor'};
+        `}
+      `}
     `;
   }}
 
@@ -120,6 +147,7 @@ const ReqoreTabsListItem = memo(
         vertical,
         onClick,
         activeIntent,
+        activeTabMarker,
         onCloseClick,
         fill,
         intent,
@@ -140,6 +168,10 @@ const ReqoreTabsListItem = memo(
       const [loadingTimer, setLoadingTimer] = useState(null);
       const { targetRef } = useCombinedRefs(ref);
       const theme = useReqoreTheme('main', customTheme, undefined);
+      // The `line` marker takes the active intent's colour when there is one, and
+      // otherwise inherits the tab's own text colour via `currentColor`.
+      const markerIntent = activeIntent || intent;
+      const activeColor = markerIntent ? theme.intents[markerIntent] : undefined;
 
       useUpdateEffect(() => {
         if (isPending) {
@@ -207,6 +239,8 @@ const ReqoreTabsListItem = memo(
           fill={fill}
           fixed={rest.fixed}
           padded={padded}
+          activeTabMarker={activeTabMarker}
+          activeColor={activeColor}
         >
           {!onCloseClick || disabled ? (
             renderButton()

--- a/src/components/Tabs/item.tsx
+++ b/src/components/Tabs/item.tsx
@@ -9,6 +9,7 @@ import {
   changeLightness,
   getColorFromMaybeString,
   getMainBackgroundColor,
+  getReadableColor,
 } from '../../helpers/colors';
 import { useCombinedRefs } from '../../hooks/useCombinedRefs';
 import { useReqoreTheme } from '../../hooks/useTheme';
@@ -117,13 +118,12 @@ export const StyledTabListItem = styled.div<IReqoreTabListItemStyle>`
 
       ${activeTabMarker === 'line' &&
       css`
-        /* Inactive tabs still have their minimal wash suppressed here — this clears
-           background-COLOR only, so a tab carrying a gradient effect keeps it (a
-           gradient is a background-image). The ACTIVE tab needs no entry: it is passed
-           the transparent prop, which the button now honours in its active state
-           instead of painting a fill and deriving the label colour from it.
-           The square corners are for the hover wash below: a rounded wash would read
-           as a pill sitting in the strip. */
+        /* The tab itself stays transparent — the active one is marked by a bar
+           along the list's edge, not a filled background, so the button's own
+           active fill has to go. The square corners are for the hover wash
+           below: a rounded wash would read as a pill sitting in the strip.
+           (The border needs no handling: a line marker forces the button flat,
+           which already zeroes its width.) */
         ${StyledButton} {
           background-color: transparent !important;
           border-radius: 0 !important;
@@ -155,6 +155,27 @@ export const StyledTabListItem = styled.div<IReqoreTabListItemStyle>`
         css`
           box-shadow: inset ${vertical ? '-2px 0 0 0' : '0 -2px 0 0'}
             ${activeColor || 'currentColor'};
+
+          /* The label has to be re-coloured wherever the background is overridden.
+             An active button derives its text colour FROM the fill it paints, so
+             suppressing that fill above leaves a colour chosen for a surface that is
+             no longer there — and with an intent the fill is light, so the label
+             resolves to near-black and disappears against the page.
+
+             Do not "fix" this by making the button honour transparent in its active
+             state: a selected menu item is transparent + active precisely so the
+             active fill can show the selection (Menu/item.tsx), and removing it there
+             makes every dropdown selection invisible. The pairing is intentional
+             elsewhere; the tab is the one place the fill is unwanted, so the tab is
+             where it is undone.
+
+             The label takes the theme's readable colour, NOT the marker colour:
+             activeTabMarkerColor exists so the bar can be coloured independently of
+             the label (a white label under a brand-coloured bar), and tinting the
+             label with it would collapse that distinction. */
+          ${StyledButton} {
+            color: ${getReadableColor(theme, undefined, undefined, false)} !important;
+          }
         `}
       `}
     `;
@@ -257,11 +278,6 @@ const ReqoreTabsListItem = memo(
           fluid={fill || vertical}
           icon={icon}
           minimal
-          /* Only the ACTIVE tab is made transparent, and only for a line marker.
-             That is the one state that paints a fill and derives its label colour from
-             it — the bug this fixes. Applying it to every tab also suppresses a tab's
-             own gradient effect, which consumers explicitly opt into. */
-          transparent={isLineMarker && active}
           wrap={wrapTabNames}
           intent={active ? activeIntent || intent : intent}
           active={active}

--- a/src/components/Tabs/item.tsx
+++ b/src/components/Tabs/item.tsx
@@ -117,12 +117,13 @@ export const StyledTabListItem = styled.div<IReqoreTabListItemStyle>`
 
       ${activeTabMarker === 'line' &&
       css`
-        /* The tab itself stays transparent — the active one is marked by a bar
-           along the list's edge, not a filled background, so the button's own
-           active fill has to go. The square corners are for the hover wash
-           below: a rounded wash would read as a pill sitting in the strip.
-           (The border needs no handling: a line marker forces the button flat,
-           which already zeroes its width.) */
+        /* Inactive tabs still have their minimal wash suppressed here — this clears
+           background-COLOR only, so a tab carrying a gradient effect keeps it (a
+           gradient is a background-image). The ACTIVE tab needs no entry: it is passed
+           the transparent prop, which the button now honours in its active state
+           instead of painting a fill and deriving the label colour from it.
+           The square corners are for the hover wash below: a rounded wash would read
+           as a pill sitting in the strip. */
         ${StyledButton} {
           background-color: transparent !important;
           border-radius: 0 !important;
@@ -256,6 +257,11 @@ const ReqoreTabsListItem = memo(
           fluid={fill || vertical}
           icon={icon}
           minimal
+          /* Only the ACTIVE tab is made transparent, and only for a line marker.
+             That is the one state that paints a fill and derives its label colour from
+             it — the bug this fixes. Applying it to every tab also suppresses a tab's
+             own gradient effect, which consumers explicitly opt into. */
+          transparent={isLineMarker && active}
           wrap={wrapTabNames}
           intent={active ? activeIntent || intent : intent}
           active={active}

--- a/src/components/Tabs/item.tsx
+++ b/src/components/Tabs/item.tsx
@@ -5,17 +5,25 @@ import styled, { css } from 'styled-components';
 import { IReqoreTabsListItem, TReqoreTabsActiveMarker } from '.';
 import { TSizes } from '../../constants/sizes';
 import { IReqoreCustomTheme, IReqoreTheme } from '../../constants/theme';
+import {
+  changeLightness,
+  getColorFromMaybeString,
+  getMainBackgroundColor,
+} from '../../helpers/colors';
 import { useCombinedRefs } from '../../hooks/useCombinedRefs';
 import { useReqoreTheme } from '../../hooks/useTheme';
 import { IWithReqoreFlat } from '../../types/global';
 import ReqoreButton, { StyledButton } from '../Button';
 import ReqoreControlGroup from '../ControlGroup';
+import { TReqoreEffectColor } from '../Effect';
 
 export interface IReqoreTabListItemProps extends IReqoreTabsListItem, IWithReqoreFlat {
   active?: boolean;
   vertical?: boolean;
   /** How the active tab is marked — see `IReqoreTabsProps.activeTabMarker`. */
   activeTabMarker?: TReqoreTabsActiveMarker;
+  /** Explicit colour for the `line` marker — see `IReqoreTabsProps`. */
+  activeTabMarkerColor?: TReqoreEffectColor;
   onCloseClick?: any;
   customTheme?: IReqoreCustomTheme;
   size?: TSizes;
@@ -34,6 +42,7 @@ export interface IReqoreTabListItemStyle extends IReqoreTabListItemProps {
 
 export const StyledTabListItem = styled.div<IReqoreTabListItemStyle>`
   ${({
+    theme,
     disabled,
     vertical,
     fill,
@@ -109,10 +118,36 @@ export const StyledTabListItem = styled.div<IReqoreTabListItemStyle>`
       ${activeTabMarker === 'line' &&
       css`
         /* The tab itself stays transparent — the active one is marked by a bar
-           along the list's edge instead of a filled background. */
+           along the list's edge, not a filled background, so the button's own
+           active fill has to go. The square corners are for the hover wash
+           below: a rounded wash would read as a pill sitting in the strip.
+           (The border needs no handling: a line marker forces the button flat,
+           which already zeroes its width.) */
         ${StyledButton} {
           background-color: transparent !important;
           border-radius: 0 !important;
+        }
+
+        /* A button draws a 2px outline on :hover, :focus and :active. On an
+           underline tab each of those reads as a boxed button fighting the bar,
+           and the :focus one OUTLASTS the interaction — it survives until you
+           click something else, which is what makes a freshly-picked tab look
+           wrong until you move on. Drop all three and give hover a wash instead. */
+        ${StyledButton}:hover,
+        ${StyledButton}:focus,
+        ${StyledButton}:active {
+          outline: none !important;
+        }
+
+        ${StyledButton}:hover {
+          background-color: ${changeLightness(getMainBackgroundColor(theme), 0.1)} !important;
+        }
+
+        /* Keyboard users still need to see where they are; :focus-visible only
+           matches keyboard focus, so this never returns on a mouse click. */
+        ${StyledButton}:focus-visible {
+          outline: 2px solid ${activeColor || changeLightness(getMainBackgroundColor(theme), 0.4)} !important;
+          outline-offset: -2px;
         }
 
         ${active &&
@@ -148,6 +183,7 @@ const ReqoreTabsListItem = memo(
         onClick,
         activeIntent,
         activeTabMarker,
+        activeTabMarkerColor,
         onCloseClick,
         fill,
         intent,
@@ -168,10 +204,17 @@ const ReqoreTabsListItem = memo(
       const [loadingTimer, setLoadingTimer] = useState(null);
       const { targetRef } = useCombinedRefs(ref);
       const theme = useReqoreTheme('main', customTheme, undefined);
-      // The `line` marker takes the active intent's colour when there is one, and
-      // otherwise inherits the tab's own text colour via `currentColor`.
+      // Marker colour, most specific first: an explicit colour, then the active
+      // intent's, and failing both the tab's own text colour via `currentColor`.
+      // The explicit one is resolved through the theme — `TReqoreEffectColor`
+      // accepts semantic values ('info', 'main:lighten:8') that are not valid CSS
+      // on their own, and dropping one straight into a box-shadow kills the rule.
       const markerIntent = activeIntent || intent;
-      const activeColor = markerIntent ? theme.intents[markerIntent] : undefined;
+      const activeColor = activeTabMarkerColor
+        ? getColorFromMaybeString(theme, activeTabMarkerColor)
+        : markerIntent
+        ? theme.intents[markerIntent]
+        : undefined;
 
       useUpdateEffect(() => {
         if (isPending) {
@@ -202,9 +245,14 @@ const ReqoreTabsListItem = memo(
         });
       };
 
+      // A `line` marker owns the active indicator, so the tab itself is always
+      // flat: a non-flat list still wants its edge rule, but boxing each tab
+      // would compete with the bar and read as a button, not a tab.
+      const isLineMarker = activeTabMarker === 'line';
+
       const renderButton = () => (
         <ReqoreButton
-          flat={intent ? false : flat}
+          flat={isLineMarker ? true : intent ? false : flat}
           fluid={fill || vertical}
           icon={icon}
           minimal
@@ -250,7 +298,7 @@ const ReqoreTabsListItem = memo(
               {onCloseClick && !disabled ? (
                 <ReqoreButton
                   fixed
-                  flat={intent ? false : flat}
+                  flat={isLineMarker ? true : intent ? false : flat}
                   icon={closeIcon || 'CloseLine'}
                   intent={active ? activeIntent || intent : intent}
                   minimal

--- a/src/components/Tabs/list.tsx
+++ b/src/components/Tabs/list.tsx
@@ -16,6 +16,7 @@ import ReqoreThemeProvider from '../../containers/ThemeProvider';
 import {
   changeLightness,
   getColorFromMaybeString,
+  getMainBackgroundColor,
   getNthGradientColor,
 } from '../../helpers/colors';
 import { calculateStringSizeInPixels, getOneLessSize } from '../../helpers/utils';
@@ -42,7 +43,7 @@ export interface IReqoreTabsListStyle extends Omit<IReqoreTabsListProps, 'tabs'>
 }
 
 export const StyledReqoreTabsList = styled.div<IReqoreTabsListStyle>`
-  ${({ fill, vertical, size, padded, flat, currentTabColor, width }) => css`
+  ${({ theme, fill, vertical, size, padded, flat, activeTabMarker, currentTabColor, width }) => css`
     height: ${vertical ? '100%' : undefined};
     width: ${vertical ? width || '200px' : '100%'};
     flex-flow: ${vertical ? 'column' : 'row'};
@@ -56,9 +57,20 @@ export const StyledReqoreTabsList = styled.div<IReqoreTabsListStyle>`
       padding: 0 ${PADDING_FROM_SIZE[size]}px;
     `}
 
-    ${!flat &&
+    ${/* A `line` marker always wants the strip's edge rule for the bar to sit on,
+        even when the tabs themselves are flat — that pairing IS the underline
+        tab. Boxing each tab (`flat={false}`) would fight the bar instead.
+
+        With a `line` marker the rule stays a NEUTRAL hairline off the background:
+        it spans every tab, so tinting it with the active tab's intent would repaint
+        the whole strip on each selection. Only the active tab's bar carries colour. */
+    (!flat || activeTabMarker === 'line') &&
     css`
-    border-${vertical ? 'right' : 'bottom'}: 1px solid ${changeLightness(currentTabColor, 0.175)};
+    border-${vertical ? 'right' : 'bottom'}: 1px solid ${
+      activeTabMarker === 'line'
+        ? changeLightness(getMainBackgroundColor(theme), 0.16)
+        : changeLightness(currentTabColor, 0.175)
+    };
     `}
 
 
@@ -252,6 +264,7 @@ type TReqoreTabListItemRendererProps = Pick<
   | 'padded'
   | 'activeIntent'
   | 'activeTabMarker'
+  | 'activeTabMarkerColor'
   | 'wrapTabNames'
   | 'loadingIconType'
   | 'useReactTransition'
@@ -317,6 +330,7 @@ const ReqoreTabsList = ({
   vertical,
   activeTabIntent,
   activeTabMarker,
+  activeTabMarkerColor,
   customTheme,
   wrapTabNames,
   flat,
@@ -357,6 +371,7 @@ const ReqoreTabsList = ({
         className={`${rest.className || ''} reqore-tabs-list`}
         ref={ref}
         flat={flat}
+        activeTabMarker={activeTabMarker}
         theme={theme}
         currentTabColor={currentTabColor}
       >
@@ -465,6 +480,7 @@ const ReqoreTabsList = ({
                 padded={padded}
                 activeIntent={activeTabIntent}
                 activeTabMarker={activeTabMarker}
+                activeTabMarkerColor={activeTabMarkerColor}
                 wrapTabNames={wrapTabNames}
                 loadingIconType={loadingIconType}
                 useReactTransition={useReactTransition}

--- a/src/components/Tabs/list.tsx
+++ b/src/components/Tabs/list.tsx
@@ -251,6 +251,7 @@ type TReqoreTabListItemRendererProps = Pick<
   | 'flat'
   | 'padded'
   | 'activeIntent'
+  | 'activeTabMarker'
   | 'wrapTabNames'
   | 'loadingIconType'
   | 'useReactTransition'
@@ -315,6 +316,7 @@ const ReqoreTabsList = ({
   fill,
   vertical,
   activeTabIntent,
+  activeTabMarker,
   customTheme,
   wrapTabNames,
   flat,
@@ -462,6 +464,7 @@ const ReqoreTabsList = ({
                 flat={flat}
                 padded={padded}
                 activeIntent={activeTabIntent}
+                activeTabMarker={activeTabMarker}
                 wrapTabNames={wrapTabNames}
                 loadingIconType={loadingIconType}
                 useReactTransition={useReactTransition}

--- a/src/constants/sizes.ts
+++ b/src/constants/sizes.ts
@@ -362,6 +362,45 @@ export const BADGE_RADIUS_FROM_RADIUS_SIZE = {
   massive: 32,
 };
 
+/**
+ * Chat bubbles carry a far rounder corner than a general surface — the curve is
+ * what reads as "speech" rather than "panel", so they get their own scale.
+ */
+export const BUBBLE_RADIUS_FROM_SIZE = {
+  micro: 9,
+  tiny: 12,
+  small: 12,
+  normal: 15,
+  big: 18,
+  huge: 24,
+  massive: 30,
+};
+
+/** More pronounced radius for `radiusSize`-driven bubble corners. */
+export const BUBBLE_RADIUS_FROM_RADIUS_SIZE = {
+  micro: 14,
+  tiny: 20,
+  small: 24,
+  normal: 30,
+  big: 40,
+  huge: 52,
+  massive: 70,
+};
+
+/**
+ * The bubble's avatar tile — squarer than the bubble it sits beside, so it reads
+ * as a distinct object rather than a second bubble.
+ */
+export const BUBBLE_AVATAR_RADIUS_FROM_SIZE = {
+  micro: 5,
+  tiny: 6,
+  small: 6,
+  normal: 8,
+  big: 10,
+  huge: 13,
+  massive: 16,
+};
+
 export const GAP_FROM_SIZE = {
   micro: 0.5,
   tiny: 1,

--- a/src/stories/Bubble/Bubble.stories.tsx
+++ b/src/stories/Bubble/Bubble.stories.tsx
@@ -120,10 +120,14 @@ export const WithTimestamp: Story = {
 export const WithHeader: Story = {
   render: Template,
   args: {
-    title: 'Ada Lovelace',
-    detail: '2h ago',
+    label: 'Ada Lovelace',
+    timestamp: '2h ago',
     flat: false,
     minimal: true,
+    // wash the body a step below the bold label — `contentEffect` hits only the
+    // children, so the label stays at full strength.
+    contentEffect: { opacity: 0.72 },
+    children: 'Adept programmer of the Analytical Engine, author of the first algorithm.',
   },
 };
 
@@ -131,17 +135,22 @@ export const WithAvatar: Story = {
   render: Template,
   args: {
     avatar: { icon: 'User3Line' },
-    title: 'Ada Lovelace',
-    detail: '2h ago',
+    label: 'Ada Lovelace',
+    timestamp: '2h ago',
     flat: false,
     minimal: true,
+    contentEffect: { opacity: 0.72 },
+    children: 'Adept programmer of the Analytical Engine, author of the first algorithm.',
   },
 };
 
 /**
- * A comment feed: an avatar + a bordered, accent-tinted card per message, each
- * side hugging its own edge. `customTheme` tints the border, the fill and the
- * avatar together, so the pair reads as one object under any app's theme.
+ * A comment feed: an avatar + a bordered, accent-tinted card per message, each side
+ * hugging its own edge. `customTheme` tints the border, the fill and the avatar
+ * together, so the pair reads as one object under any app's theme. All three bubbles
+ * carry a `timestamp`, but the two right-side ones form a run — so only the last of
+ * them prints a time. `contentEffect={{ opacity }}` washes each body a step below its
+ * bold label (the label sits outside `contentEffect`, so it stays bright).
  */
 export const AvatarFeed: Story = {
   render: () => (
@@ -149,8 +158,9 @@ export const AvatarFeed: Story = {
       <ReqoreBubble
         align='left'
         avatar={{ icon: 'User3Line' }}
-        title='ops@acme.io'
-        detail='2h ago'
+        label='ops@acme.io'
+        timestamp='2h ago'
+        contentEffect={{ opacity: 0.72 }}
         customTheme={{ main: '#3b2d63' }}
         maxWidth='76%'
         flat={false}
@@ -161,8 +171,9 @@ export const AvatarFeed: Story = {
       <ReqoreBubble
         align='right'
         avatar={{ icon: 'CustomerService2Line' }}
-        title='Support'
-        detail='1h ago'
+        label='Support'
+        timestamp='1h ago'
+        contentEffect={{ opacity: 0.72 }}
         customTheme={{ main: '#3b2d63' }}
         maxWidth='76%'
         flat={false}
@@ -173,8 +184,9 @@ export const AvatarFeed: Story = {
       <ReqoreBubble
         align='right'
         avatar={{ icon: 'EyeOffLine' }}
-        title='Internal note'
-        detail='35m ago'
+        label='Internal note'
+        timestamp='35m ago'
+        contentEffect={{ opacity: 0.72 }}
         intent='warning'
         maxWidth='76%'
         flat={false}

--- a/src/stories/Bubble/Bubble.stories.tsx
+++ b/src/stories/Bubble/Bubble.stories.tsx
@@ -145,6 +145,24 @@ export const WithAvatar: Story = {
 };
 
 /**
+ * `avatar.circle` swaps the default squircle for a circle — conventional for a
+ * person, where the squircle reads as an app tile. The image is clipped to the
+ * new shape, so a photo works as well as a glyph.
+ */
+export const WithCircleAvatar: Story = {
+  render: Template,
+  args: {
+    avatar: { icon: 'User3Line', circle: true },
+    label: 'Ada Lovelace',
+    timestamp: '2h ago',
+    flat: false,
+    minimal: true,
+    contentEffect: { opacity: 0.72 },
+    children: 'Adept programmer of the Analytical Engine, author of the first algorithm.',
+  },
+};
+
+/**
  * A comment feed: an avatar + a bordered, accent-tinted card per message, each side
  * hugging its own edge. `customTheme` tints the border, the fill and the avatar
  * together, so the pair reads as one object under any app's theme. All three bubbles

--- a/src/stories/Bubble/Bubble.stories.tsx
+++ b/src/stories/Bubble/Bubble.stories.tsx
@@ -1,7 +1,7 @@
 import { StoryFn, StoryObj } from '@storybook/react';
 import { ReqoreBubble, ReqoreBubbleGroup, IReqoreBubbleProps } from '../../components/Bubble';
 import { StoryMeta } from '../utils';
-import { FlatArg, IntentArg, MinimalArg, SizeArg, argManager } from '../utils/args';
+import { FlatArg, IntentArg, MinimalArg, RadiusSizeArg, SizeArg, argManager } from '../utils/args';
 
 const { createArg } = argManager<IReqoreBubbleProps>();
 
@@ -13,6 +13,7 @@ const meta = {
     ...FlatArg,
     ...MinimalArg,
     ...IntentArg,
+    ...RadiusSizeArg,
     ...createArg('align', {
       defaultValue: 'left',
       name: 'Align',
@@ -114,6 +115,75 @@ export const WithTimestamp: Story = {
   args: {
     timestamp: '10:45 AM',
   },
+};
+
+export const WithHeader: Story = {
+  render: Template,
+  args: {
+    title: 'Ada Lovelace',
+    detail: '2h ago',
+    flat: false,
+    minimal: true,
+  },
+};
+
+export const WithAvatar: Story = {
+  render: Template,
+  args: {
+    avatar: { icon: 'User3Line' },
+    title: 'Ada Lovelace',
+    detail: '2h ago',
+    flat: false,
+    minimal: true,
+  },
+};
+
+/**
+ * A comment feed: an avatar + a bordered, accent-tinted card per message, each
+ * side hugging its own edge. `customTheme` tints the border, the fill and the
+ * avatar together, so the pair reads as one object under any app's theme.
+ */
+export const AvatarFeed: Story = {
+  render: () => (
+    <ReqoreBubbleGroup>
+      <ReqoreBubble
+        align='left'
+        avatar={{ icon: 'User3Line' }}
+        title='ops@acme.io'
+        detail='2h ago'
+        customTheme={{ main: '#3b2d63' }}
+        maxWidth='76%'
+        flat={false}
+        minimal
+      >
+        Our nightly transfer times out after ~30s since the 3.2 upgrade.
+      </ReqoreBubble>
+      <ReqoreBubble
+        align='right'
+        avatar={{ icon: 'CustomerService2Line' }}
+        title='Support'
+        detail='1h ago'
+        customTheme={{ main: '#3b2d63' }}
+        maxWidth='76%'
+        flat={false}
+        minimal
+      >
+        Reproduced — a fix is in review. Can you confirm the pool size?
+      </ReqoreBubble>
+      <ReqoreBubble
+        align='right'
+        avatar={{ icon: 'EyeOffLine' }}
+        title='Internal note'
+        detail='35m ago'
+        intent='warning'
+        maxWidth='76%'
+        flat={false}
+        minimal
+      >
+        The pool default dropped from 4 to 1 in the 3.2 migration.
+      </ReqoreBubble>
+    </ReqoreBubbleGroup>
+  ),
 };
 
 export const Clickable: Story = {

--- a/src/stories/DescriptionList/DescriptionList.stories.tsx
+++ b/src/stories/DescriptionList/DescriptionList.stories.tsx
@@ -1,4 +1,5 @@
 import { StoryObj } from '@storybook/react';
+import { expect } from 'storybook/test';
 import ReqoreControlGroup from '../../components/ControlGroup';
 import {
   IReqoreDescriptionListProps,
@@ -6,6 +7,7 @@ import {
 } from '../../components/DescriptionList';
 import { ReqoreSpan } from '../../components/Span';
 import ReqoreTag from '../../components/Tag';
+import { ReqoreButton, ReqoreDropdown } from '../../index';
 import { StoryMeta } from '../utils';
 
 const meta = {
@@ -324,5 +326,107 @@ export const LeadingTagInContent: Story = {
         content: <ReqoreTag size='small' minimal label='text-embedding-3-small' />,
       },
     ],
+  },
+};
+
+/*
+ * A list whose values are a mix of plain text and controls. `contentSize` sizes the
+ * content column for controls, which is what keeps such a list tabular: without it a
+ * text row is ~18px and a button row 32px, and a button insets its own label by its
+ * horizontal padding while bare text starts at the column edge — so the rows differ
+ * in height AND the values never share a left edge.
+ */
+const mixedItems: IReqoreDescriptionListProps['items'] = [
+  {
+    key: 'status',
+    label: 'Status',
+    content: (
+      <ReqoreDropdown
+        size='small'
+        minimal
+        flat
+        label='Open'
+        showCaret={false}
+        rightIcon='ArrowDownSLine'
+        items={[{ label: 'Open', selected: true }, { label: 'Resolved' }]}
+      />
+    ),
+  },
+  { key: 'owner', label: 'Owner', content: 'nick.m@acme.io' },
+  { key: 'scope', label: 'Scope', content: 'account:1' },
+  {
+    key: 'links',
+    label: 'Links',
+    content: (
+      <ReqoreButton size='small' minimal flat icon='GitBranchLine'>
+        5 references
+      </ReqoreButton>
+    ),
+  },
+];
+
+export const WithControlContent: Story = {
+  args: {
+    label: 'Ticket',
+    flat: true,
+    size: 'small',
+    contentSize: 'small',
+    labelTextSize: 'tiny',
+    rowPadding: 'tiny',
+    labelWidth: '84px',
+    items: mixedItems,
+  },
+  play: async ({ canvasElement }) => {
+    const rows = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>('.reqore-description-list-row')
+    );
+    await expect(rows.length).toBe(4);
+
+    /* Where the value's CONTENT starts, not where its box does. The inset is padding
+       and it lands on the value itself — the button on a control row, the paragraph on
+       a text row — so measure that child's padded edge. Measuring the column instead
+       reads the same number for every row and proves nothing. */
+    const contentLeft = (row: HTMLElement) => {
+      const column = row.querySelector<HTMLElement>('.reqore-description-list-content')!;
+      const value = (column.firstElementChild as HTMLElement | null) ?? column;
+      return Math.round(
+        value.getBoundingClientRect().left + parseFloat(getComputedStyle(value).paddingLeft)
+      );
+    };
+
+    const lefts = rows.map(contentLeft);
+    await expect(new Set(lefts).size, `value content starts at: ${lefts.join(', ')}`).toBe(1);
+
+    const heights = rows.map((row) => Math.round(row.getBoundingClientRect().height));
+    await expect(new Set(heights).size, `row heights: ${heights.join(', ')}`).toBe(1);
+    // `rowPadding` makes that height predictable: a small control plus tiny padding
+    // either side. A list a tab strip is aligned to needs to be able to state this.
+    await expect(heights[0]).toBe(32 + 4 * 2);
+
+    // `labelTextSize` keeps the longest label on one line inside `labelWidth`
+    const labels = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>('.reqore-description-list-label')
+    );
+    const labelHeights = labels.map((l) => Math.round(l.getBoundingClientRect().height));
+    await expect(new Set(labelHeights).size, `label heights: ${labelHeights.join(', ')}`).toBe(1);
+  },
+};
+
+/**
+ * The separator is painted, not laid out — so every row is the same height, including
+ * the last one, which carries no separator at all.
+ */
+export const SeparatorDoesNotChangeRowHeight: Story = {
+  args: {
+    label: 'Lifecycle',
+    flat: true,
+    items: lifecycleItems,
+  },
+  play: async ({ canvasElement }) => {
+    const heights = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>('.reqore-description-list-row')
+    ).map((row) => Math.round(row.getBoundingClientRect().height));
+    await expect(heights.length).toBeGreaterThan(1);
+    await expect(new Set(heights).size, `row heights: ${heights.join(', ')}`).toBe(1);
   },
 };

--- a/src/stories/EntityRow/EntityRow.stories.tsx
+++ b/src/stories/EntityRow/EntityRow.stories.tsx
@@ -302,3 +302,35 @@ export const CustomPaddingSize: Story = {
     </ReqoreControlGroup>
   ),
 };
+
+/**
+ * An action carrying `actions` becomes an overflow menu rather than a button — the
+ * same contract as `ReqorePanel`'s actions. This is how a row gets a "three dots"
+ * menu without the consumer hand-rolling a dropdown next to the row.
+ *
+ * The menu stops its own click, so a row that is itself clickable does not fire when
+ * the menu is opened.
+ */
+export const WithOverflowMenu: Story = {
+  args: {
+    label: 'order-sync:1.0',
+    description: 'Referenced in the ticket description',
+    metadata: 'workflow',
+    icon: 'GitBranchLine',
+    actions: [
+      { icon: 'ArrowRightUpLine', tooltip: 'Open' },
+      {
+        icon: 'More2Line',
+        tooltip: 'More actions',
+        actions: [
+          { label: 'Show in chat', icon: 'Chat1Line' },
+          { label: 'Copy name', icon: 'FileCopyLine' },
+          { divider: true, line: true },
+          { label: 'Remove reference', icon: 'DeleteBinLine', intent: 'danger' },
+          // entries can be hidden without the consumer filtering the array itself
+          { label: 'Never rendered', show: false },
+        ],
+      },
+    ],
+  },
+};

--- a/src/stories/Tabs/Tabs.stories.tsx
+++ b/src/stories/Tabs/Tabs.stories.tsx
@@ -317,6 +317,39 @@ export const NotFlat: Story = {
   },
 };
 
+/** `activeTabMarker='line'` leaves the tab transparent and marks the active one
+ *  with a bar on the list's edge — the quieter treatment for dense surfaces. */
+export const ActiveTabMarkerLine: Story = {
+  render: Template,
+
+  args: {
+    activeTabMarker: 'line',
+    flat: false,
+  },
+};
+
+/** The `line` marker takes the active intent's colour when one is set. */
+export const ActiveTabMarkerLineWithIntent: Story = {
+  render: Template,
+
+  args: {
+    activeTabMarker: 'line',
+    activeTabIntent: 'info',
+    flat: false,
+  },
+};
+
+/** Vertical tabs move the `line` marker to the strip's trailing edge. */
+export const ActiveTabMarkerLineVertical: Story = {
+  render: Template,
+
+  args: {
+    activeTabMarker: 'line',
+    vertical: true,
+    flat: false,
+  },
+};
+
 export const WithPadding: Story = {
   render: Template,
 

--- a/src/stories/Tabs/Tabs.stories.tsx
+++ b/src/stories/Tabs/Tabs.stories.tsx
@@ -346,7 +346,7 @@ export const ActiveTabMarkerLineColor: Story = {
 
   args: {
     activeTabMarker: 'line',
-    activeTabMarkerColor: 'main:lighten:8',
+    activeTabMarkerColor: 'info:lighten:8',
   },
 };
 

--- a/src/stories/Tabs/Tabs.stories.tsx
+++ b/src/stories/Tabs/Tabs.stories.tsx
@@ -339,6 +339,17 @@ export const ActiveTabMarkerLineWithIntent: Story = {
   },
 };
 
+/** `activeTabMarkerColor` gives the bar an accent the label doesn't carry —
+ *  the usual underline-tab treatment (bright label, coloured bar). */
+export const ActiveTabMarkerLineColor: Story = {
+  render: Template,
+
+  args: {
+    activeTabMarker: 'line',
+    activeTabMarkerColor: 'main:lighten:8',
+  },
+};
+
 /** Vertical tabs move the `line` marker to the strip's trailing edge. */
 export const ActiveTabMarkerLineVertical: Story = {
   render: Template,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ import { defineConfig, mergeConfig } from 'vitest/config';
 import viteConfig from './vite.config';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
+const qlipUploadToken = process.env.QLIP_UPLOAD_TOKEN;
 
 export default mergeConfig(
   viteConfig,
@@ -24,10 +25,8 @@ export default mergeConfig(
               disableAnimations: true,
               pauseAnimationsAtEnd: true,
               viewport: { width: 1920, height: 1080 },
-              upload: {
-                // serverUrl omitted — defaults to https://qlip.qoretechnologies.com
-                uploadToken: 'qlt_L5HfLmW8KqGTY5ap6OxBf0nfFBohS2PHzKgQBdyK',
-              },
+              // serverUrl omitted — defaults to https://qlip.qoretechnologies.com
+              ...(qlipUploadToken ? { upload: { uploadToken: qlipUploadToken } } : {}),
             }),
             storybookTest({
               configDir: path.join(dirname, '.storybook'),


### PR DESCRIPTION
A ticket thread wants an avatar beside a bordered, accent-tinted card per message, with the author and time on the card's first line. ReqoreBubble already had the alignment, width cap, tint and border; ReqoreComment had the avatar and title but is a full-width panel with room for actions. Rather than add a third component, the two missing pieces land on the bubble.

`avatar={{ icon | image }}` renders outside the bubble on the side it hugs, tinted at the same strength a `minimal` bubble uses so the pair reads as one object. It wraps the bubble in a row that takes over the alignment — a bubble without an avatar renders exactly as before, so existing transcripts are untouched. `title`/`detail` render as an inline header (bold author, muted time), each with its own `titleEffect`/`detailEffect` per Appendix A.7. `detail` is distinct from `timestamp`, which stays at the bottom-right.

`radiusSize` now drives the bubble's corners and the avatar's alike, through `resolveRadius` + BUBBLE_RADIUS_FROM_SIZE / BUBBLE_RADIUS_FROM_RADIUS_SIZE / BUBBLE_AVATAR_RADIUS_FROM_SIZE — replacing the bare `RADIUS_FROM_SIZE * 3` literal. The new size scale reproduces that multiplier exactly at every size, so default corners are unchanged. The cluster seam stays on RADIUS_FROM_SIZE: its contrast against the outer curve is what makes a run read as one bubble.

Adds __tests__/bubble.test.tsx — the component had none. Covers the class hooks, both negative cases (no header without title/detail, no row without an avatar), avatar side-ordering, and the radiusSize wiring. 709 unit tests, 13 Bubble stories, lint and tsc green.