### PR TITLE
Fix remaining styling props leaking into DOM elements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.claude/CLAUDE.md

--- a/__tests__/popover-resize.test.tsx
+++ b/__tests__/popover-resize.test.tsx
@@ -1,0 +1,71 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { ReqorePopover, ReqoreUIProvider } from '../src';
+
+const popper = vi.hoisted(() => ({
+  forceUpdate: vi.fn(),
+}));
+
+vi.mock('react-popper', () => ({
+  usePopper: () => ({
+    styles: { popper: {}, arrow: {} },
+    attributes: { popper: {} },
+    forceUpdate: popper.forceUpdate,
+    state: {},
+  }),
+}));
+
+class TestResizeObserver {
+  static instances: TestResizeObserver[] = [];
+
+  readonly observe = vi.fn();
+  readonly disconnect = vi.fn();
+
+  constructor(readonly callback: ResizeObserverCallback) {
+    TestResizeObserver.instances.push(this);
+  }
+}
+
+const Preview = ({ updater }: { updater: number }) => (
+  <ReqoreUIProvider>
+    <ReqorePopover
+      component='span'
+      content={<div>Asynchronous preview</div>}
+      openOnMount
+      updater={updater}
+    >
+      Preview trigger
+    </ReqorePopover>
+  </ReqoreUIProvider>
+);
+
+beforeEach(() => {
+  popper.forceUpdate.mockClear();
+  TestResizeObserver.instances = [];
+  vi.stubGlobal('ResizeObserver', TestResizeObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test('repositions an open popover when asynchronous content changes size', async () => {
+  render(<Preview updater={0} />);
+  expect(await screen.findByText('Asynchronous preview')).toBeInTheDocument();
+
+  await waitFor(() => expect(TestResizeObserver.instances).toHaveLength(1));
+  const observer = TestResizeObserver.instances[0];
+  expect(observer.observe).toHaveBeenCalledWith(document.querySelector('.reqore-popover-content'));
+
+  act(() => observer.callback([], observer as unknown as ResizeObserver));
+  expect(popper.forceUpdate).toHaveBeenCalled();
+});
+
+test('honors the explicit updater prop while the popover is open', async () => {
+  const { rerender } = render(<Preview updater={0} />);
+  expect(await screen.findByText('Asynchronous preview')).toBeInTheDocument();
+  popper.forceUpdate.mockClear();
+
+  rerender(<Preview updater={1} />);
+  expect(popper.forceUpdate).toHaveBeenCalled();
+});

--- a/__tests__/popover.test.tsx
+++ b/__tests__/popover.test.tsx
@@ -33,6 +33,18 @@ beforeAll(() => {
   vi.useFakeTimers();
 });
 
+test('Does not forward customTheme to a native trigger', () => {
+  render(
+    <ReqoreUIProvider>
+      <ReqorePopover component='span' content='Preview' customTheme={{ main: '#123456' }}>
+        Native trigger
+      </ReqorePopover>
+    </ReqoreUIProvider>
+  );
+
+  expect(screen.getByText('Native trigger')).not.toHaveAttribute('customTheme');
+});
+
 test('Shows popover on hover, hides on leave', async () => {
   render(
     <ReqoreUIProvider>

--- a/__tests__/tag.test.tsx
+++ b/__tests__/tag.test.tsx
@@ -39,6 +39,22 @@ test('Renders <Tag /> properly', () => {
   expect(document.querySelectorAll('.reqore-tag').length).toBe(3);
 });
 
+test('Does not forward tag layout props to DOM elements', () => {
+  render(
+    <ReqoreUIProvider>
+      <ReqoreTagGroup wrap fluid align='center' gapSize='small'>
+        <ReqoreTag label='Wrapped tag' wrap width='180px' />
+      </ReqoreTagGroup>
+    </ReqoreUIProvider>
+  );
+
+  expect(document.querySelector('[wrap]')).toBeNull();
+  expect(document.querySelector('[haswidth]')).toBeNull();
+  expect(document.querySelector('[gapsize]')).toBeNull();
+  expect(document.querySelector('[fluid]')).toBeNull();
+  expect(document.querySelector('[align]')).toBeNull();
+});
+
 test('Renders <Tag /> group properly', () => {
   render(
     <ReqoreUIProvider>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.70.11",
+  "version": "0.70.13",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.70.13",
+  "version": "0.70.14",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/InternalPopover/index.tsx
+++ b/src/components/InternalPopover/index.tsx
@@ -189,6 +189,7 @@ const InternalPopover: React.FC<IReqoreInternalPopoverProps> = memo(
     flat = true,
     effect,
     backgroundBlur,
+    updater,
     id,
     onPopperUpdate,
     onPopperClose,
@@ -203,6 +204,7 @@ const InternalPopover: React.FC<IReqoreInternalPopoverProps> = memo(
     const [arrowElement, setArrowElement] = useState(null);
     const popperRef: MutableRefObject<any> = useRef(null);
     const mutationObserber: MutableRefObject<any> = useRef(null);
+    const resizeObserver = useRef<ResizeObserver | null>(null);
     const baseOffsetY = noArrow ? 5 : 10;
     const { styles, attributes, forceUpdate, state } = usePopper(targetElement, popperElement, {
       placement,
@@ -249,6 +251,32 @@ const InternalPopover: React.FC<IReqoreInternalPopoverProps> = memo(
         mutationObserber.current = observer;
       }
     }, [styles, attributes, state]);
+
+    // Popover content commonly changes size after opening (for example when
+    // an async preview replaces its skeleton). Popper's event listeners track
+    // viewport and target movement, but not intrinsic content-size changes.
+    // Recalculate deterministically whenever the rendered popover resizes so
+    // flip/preventOverflow can keep the whole surface inside the viewport.
+    useEffect(() => {
+      resizeObserver.current?.disconnect();
+      resizeObserver.current = null;
+      if (!popperElement || typeof ResizeObserver === 'undefined') return undefined;
+
+      const observer = new ResizeObserver(() => forceUpdate?.());
+      observer.observe(popperElement);
+      resizeObserver.current = observer;
+
+      return () => {
+        observer.disconnect();
+        if (resizeObserver.current === observer) resizeObserver.current = null;
+      };
+    }, [forceUpdate, popperElement]);
+
+    // Preserve the documented explicit update contract as a fallback for
+    // content changes that do not affect the content box dimensions.
+    useUpdateEffect(() => {
+      forceUpdate?.();
+    }, [updater]);
 
     // Stabilize the popover against ancestor CSS transitions that Popper's
     // scroll/resize listeners can't observe. When a popover opens inside a
@@ -297,6 +325,7 @@ const InternalPopover: React.FC<IReqoreInternalPopoverProps> = memo(
 
     useUnmount(() => {
       mutationObserber.current?.disconnect();
+      resizeObserver.current?.disconnect();
     });
 
     useEffect(() => {

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -458,6 +458,13 @@ export const ReqorePopover = memo(
         targetRef.current = r;
       }, []);
 
+      // Theme props are meaningful to Reqore/custom components, but React
+      // warns if they are forwarded to a native trigger such as `span`.
+      const triggerThemeProps =
+        typeof Component === 'string'
+          ? {}
+          : { customTheme: componentProps?.customTheme ?? customTheme };
+
       if (isReqoreComponent) {
         return (
           <>
@@ -495,8 +502,8 @@ export const ReqorePopover = memo(
             <Component
               // Forward the popover's own `customTheme` to the trigger
               // so it inherits the surrounding theme cascade. Caller
-                // wins if they already set one on `componentProps`.
-              customTheme={componentProps?.customTheme ?? customTheme}
+              // wins if they already set one on `componentProps`.
+              {...triggerThemeProps}
               {...componentProps}
               className={`${isOpen && blur ? 'reqore-blur-z-index' : ''} ${
                 componentProps?.className || ''
@@ -553,7 +560,7 @@ export const ReqorePopover = memo(
               // popover's own `customTheme` to the trigger so it
               // inherits the surrounding theme cascade. Caller wins
               // if they already set one on `componentProps`.
-              customTheme={componentProps?.customTheme ?? customTheme}
+              {...triggerThemeProps}
               {...componentProps}
             >
               {children}

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -142,6 +142,7 @@ export const ReqorePopover = memo(
         minimal,
         intent,
         id,
+        updater,
         backgroundBlur,
         // `customTheme` is picked up so it can be forwarded to the
         // trigger `Component` below. Historically the popover's own
@@ -492,6 +493,7 @@ export const ReqorePopover = memo(
                 onPopperClose={close}
                 onPopperUpdate={handlePopperUpdate}
                 id={id}
+                updater={updater}
                 handler={handler}
                 backgroundBlur={backgroundBlur}
                 onPopoverMouseEnter={keepOpenOnHover ? handlePopoverMouseEnter : undefined}
@@ -542,6 +544,7 @@ export const ReqorePopover = memo(
               onPopperUpdate={handlePopperUpdate}
               closePopover={close}
               id={id}
+              updater={updater}
               handler={handler}
               backgroundBlur={backgroundBlur}
               onPopoverMouseEnter={keepOpenOnHover ? handlePopoverMouseEnter : undefined}

--- a/src/components/Tag/group.tsx
+++ b/src/components/Tag/group.tsx
@@ -4,9 +4,7 @@ import { GAP_FROM_SIZE, TSizes } from '../../constants/sizes';
 import { IWithReqoreMinimal, IWithReqoreSize } from '../../types/global';
 
 export interface IReqoreTagGroup
-  extends React.HTMLAttributes<HTMLDivElement>,
-    IWithReqoreSize,
-    IWithReqoreMinimal {
+  extends React.HTMLAttributes<HTMLDivElement>, IWithReqoreSize, IWithReqoreMinimal {
   children: any;
   gapSize?: TSizes;
   columns?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
@@ -15,23 +13,30 @@ export interface IReqoreTagGroup
   align?: 'left' | 'center' | 'right';
 }
 
-const StyledTagGroup = styled.div`
-  flex-shrink: ${({ wrap }: IReqoreTagGroup) => (wrap ? 1 : 0)};
-  flex-grow: ${({ fluid }: IReqoreTagGroup) => (fluid ? 1 : undefined)};
+interface IStyledTagGroupProps {
+  $align?: IReqoreTagGroup['align'];
+  $fluid?: boolean;
+  $gapSize: TSizes;
+  $wrap: boolean;
+}
+
+const StyledTagGroup = styled.div<IStyledTagGroupProps>`
+  flex-shrink: ${({ $wrap }) => ($wrap ? 1 : 0)};
+  flex-grow: ${({ $fluid }) => ($fluid ? 1 : undefined)};
   display: flex;
-  flex-wrap: ${({ wrap }: IReqoreTagGroup) => (wrap ? 'wrap' : 'nowrap')};
-  gap: ${({ gapSize }: IReqoreTagGroup) => GAP_FROM_SIZE[gapSize]}px;
+  flex-wrap: ${({ $wrap }) => ($wrap ? 'wrap' : 'nowrap')};
+  gap: ${({ $gapSize }) => GAP_FROM_SIZE[$gapSize]}px;
   align-items: center;
 
-  ${({ align }) => {
-    if (align === 'right') {
+  ${({ $align }) => {
+    if ($align === 'right') {
       return css`
         margin-left: auto;
         justify-content: flex-end;
       `;
     }
 
-    if (align === 'center') {
+    if ($align === 'center') {
       return css`
         margin: 0 auto;
         justify-content: center;
@@ -48,12 +53,16 @@ const ReqoreTagGroup = ({
   className,
   columns,
   wrap = true,
+  fluid,
+  align,
   ...rest
 }: IReqoreTagGroup) => (
   <StyledTagGroup
     {...rest}
-    gapSize={gapSize}
-    wrap={wrap}
+    $align={align}
+    $fluid={fluid}
+    $gapSize={gapSize}
+    $wrap={wrap}
     className={`${className || ''} reqore-tag-group`}
   >
     {React.Children.map(children, (child) =>

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -52,17 +52,15 @@ import ReqoreIcon, { IReqoreIconProps } from '../Icon';
 import { ReqoreTooltipComponent } from '../TooltipComponent';
 
 export interface IReqoreTagAction
-  extends IWithReqoreTooltip,
-    IReqoreDisabled,
-    IReqoreIntent,
-    HTMLAttributes<HTMLSpanElement> {
+  extends IWithReqoreTooltip, IReqoreDisabled, IReqoreIntent, HTMLAttributes<HTMLSpanElement> {
   icon: IReqoreIconName;
   show?: boolean | 'hover';
   onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 export interface IReqoreCustomTagProps
-  extends IWithReqoreTooltip,
+  extends
+    IWithReqoreTooltip,
     IReqoreDisabled,
     IWithReqoreMinimal,
     IWithReqoreFluid,
@@ -102,7 +100,8 @@ export interface IReqoreCustomTagProps
   compact?: boolean;
 }
 export interface IReqoreTagProps
-  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children' | 'color'>,
+  extends
+    Omit<React.HTMLAttributes<HTMLSpanElement>, 'children' | 'color'>,
     IReqoreCustomTagProps {}
 
 export interface IReqoreTagStyle extends IReqoreTagProps {
@@ -110,6 +109,8 @@ export interface IReqoreTagStyle extends IReqoreTagProps {
   removable?: boolean;
   interactive?: boolean;
   color?: TReqoreColor;
+  $wrap?: boolean;
+  $hasWidth?: boolean;
 }
 
 export const StyledTag = styled(StyledEffect)<IReqoreTagStyle>`
@@ -134,8 +135,8 @@ export const StyledTag = styled(StyledEffect)<IReqoreTagStyle>`
     rounded === false
       ? undefined
       : asBadge
-      ? `${resolveRadius(size, radiusSize, BADGE_RADIUS_FROM_SIZE, BADGE_RADIUS_FROM_RADIUS_SIZE)}px`
-      : `${resolveRadius(size, radiusSize, TAG_RADIUS_FROM_SIZE, TAG_RADIUS_FROM_RADIUS_SIZE)}px`};
+        ? `${resolveRadius(size, radiusSize, BADGE_RADIUS_FROM_SIZE, BADGE_RADIUS_FROM_RADIUS_SIZE)}px`
+        : `${resolveRadius(size, radiusSize, TAG_RADIUS_FROM_SIZE, TAG_RADIUS_FROM_RADIUS_SIZE)}px`};
   width: ${({ width }) => width || undefined};
   transition: all 0.2s ease-out;
 
@@ -161,8 +162,8 @@ export const StyledTag = styled(StyledEffect)<IReqoreTagStyle>`
 
   ${InactiveIconScale};
 
-  ${({ wrap, hasWidth }) =>
-    wrap || hasWidth
+  ${({ $wrap, $hasWidth }) =>
+    $wrap || $hasWidth
       ? css`
           min-height: ${({ size, asBadge }) =>
             asBadge ? BADGE_SIZE_TO_PX[size] : TAG_SIZE_TO_PX[size]}px;
@@ -182,8 +183,8 @@ export const StyledTag = styled(StyledEffect)<IReqoreTagStyle>`
       color: ${minimal && color && color !== 'transparent' && !isAchromatic(color)
         ? saturate(1, tint(0.8, color))
         : color && color !== 'transparent'
-        ? getReadableColorFrom(color)
-        : getReadableColorFrom(changeLightness(theme.main, 0.1))};
+          ? getReadableColorFrom(color)
+          : getReadableColorFrom(changeLightness(theme.main, 0.1))};
 
       ${StyledTagKeyWrapper} {
         background-color: ${labelKey ? rgba('#000000', minimal ? 0.1 : 0.3) : undefined};
@@ -211,8 +212,8 @@ export const StyledTag = styled(StyledEffect)<IReqoreTagStyle>`
               color: ${minimal
                 ? getReadableColor(theme, undefined, undefined, false, theme.originalMain)
                 : color
-                ? getReadableColorFrom(color)
-                : getReadableColor(theme, undefined, undefined)};
+                  ? getReadableColorFrom(color)
+                  : getReadableColor(theme, undefined, undefined)};
             `}
           }
         `
@@ -240,7 +241,7 @@ export const StyledTag = styled(StyledEffect)<IReqoreTagStyle>`
   }
 `;
 
-const StyledTagKeyWrapper = styled.span<{ size: TSizes }>`
+const StyledTagKeyWrapper = styled.span<{ size: TSizes; $wrap?: boolean; $hasWidth?: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -252,7 +253,11 @@ const StyledTagKeyWrapper = styled.span<{ size: TSizes }>`
     padOnRight && `${TAG_HORIZONTAL_PADDING_FROM_SIZE[size]}px`};
 `;
 
-const StyledTagContentWrapper = styled.span<{ size: TSizes }>`
+const StyledTagContentWrapper = styled.span<{
+  size: TSizes;
+  $wrap?: boolean;
+  $hasWidth?: boolean;
+}>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -261,7 +266,11 @@ const StyledTagContentWrapper = styled.span<{ size: TSizes }>`
   min-height: 100%;
 `;
 
-const StyledTagContent = styled(StyledTextEffect)<{ size: TSizes }>`
+const StyledTagContent = styled(StyledTextEffect)<{
+  size: TSizes;
+  $wrap?: boolean;
+  $hasWidth?: boolean;
+}>`
   padding: 4px ${({ size }) => TAG_HORIZONTAL_PADDING_FROM_SIZE[size]}px;
   min-height: 100%;
   display: flex;
@@ -272,12 +281,12 @@ const StyledTagContent = styled(StyledTextEffect)<{ size: TSizes }>`
     justify-content: ${labelAlign === 'left'
       ? 'flex-start'
       : labelAlign === 'right'
-      ? 'flex-end'
-      : 'center'};
+        ? 'flex-end'
+        : 'center'};
   `}
 
-  ${({ wrap, hasWidth }) =>
-    !wrap && !hasWidth
+  ${({ $wrap, $hasWidth }) =>
+    !$wrap && !$hasWidth
       ? css`
           overflow: hidden;
           text-overflow: ellipsis;
@@ -291,8 +300,8 @@ const StyledTagContent = styled(StyledTextEffect)<{ size: TSizes }>`
 const StyledTagContentKey = styled(StyledTagContent)`
   flex: 1;
 
-  ${({ wrap, hasWidth }) =>
-    !wrap && !hasWidth
+  ${({ $wrap, $hasWidth }) =>
+    !$wrap && !$hasWidth
       ? undefined
       : css`
           word-break: break-word;
@@ -343,7 +352,7 @@ const ReqoreTag = forwardRef<HTMLSpanElement, IReqoreTagProps>(
       color,
       minimal,
       customTheme,
-        inheritCustomTheme,
+      inheritCustomTheme,
       wrap = false,
       width,
       leftIconColor,
@@ -362,7 +371,13 @@ const ReqoreTag = forwardRef<HTMLSpanElement, IReqoreTagProps>(
     }: IReqoreTagProps,
     ref
   ) => {
-    const theme: IReqoreTheme = useReqoreTheme('main', customTheme, undefined, undefined, inheritCustomTheme);
+    const theme: IReqoreTheme = useReqoreTheme(
+      'main',
+      customTheme,
+      undefined,
+      undefined,
+      inheritCustomTheme
+    );
 
     // If color or intent was specified, set the color
     const getCustomColor = useCallback(
@@ -414,16 +429,16 @@ const ReqoreTag = forwardRef<HTMLSpanElement, IReqoreTagProps>(
         removable={!!onRemoveClick}
         interactive={!!onClick && !rest.disabled}
         tabIndex={onClick && !rest.disabled ? 0 : undefined}
-        wrap={wrap}
-        hasWidth={!!width}
+        $wrap={wrap}
+        $hasWidth={!!width}
       >
         {labelKey || hasLeftIcon ? (
           <StyledTagKeyWrapper
             size={size}
             className='reqore-tag-key-content'
             onClick={rest.disabled ? undefined : onClick}
-            wrap={wrap}
-            hasWidth={!!width}
+            $wrap={wrap}
+            $hasWidth={!!width}
             hasKey={!!labelKey}
             hasIcon={hasLeftIcon}
             padOnRight={!label && !labelKey && !hasRightIcon}
@@ -444,8 +459,8 @@ const ReqoreTag = forwardRef<HTMLSpanElement, IReqoreTagProps>(
             ) : null}
             {labelKey && (
               <StyledTagContentKey
-                wrap={wrap}
-                hasWidth={!!width}
+                $wrap={wrap}
+                $hasWidth={!!width}
                 size={size}
                 labelAlign={labelKeyAlign}
                 compact={compact}
@@ -466,16 +481,16 @@ const ReqoreTag = forwardRef<HTMLSpanElement, IReqoreTagProps>(
             size={size}
             className='reqore-tag-content'
             onClick={rest.disabled ? undefined : onClick}
-            wrap={wrap}
-            hasWidth={!!width}
+            $wrap={wrap}
+            $hasWidth={!!width}
             hasKey={!!labelKey}
             fixed={rest.fixed}
           >
             {label || label === 0 ? (
               <StyledTagContent
                 size={size}
-                wrap={wrap}
-                hasWidth={!!width}
+                $wrap={wrap}
+                $hasWidth={!!width}
                 labelAlign={labelAlign || (labelKey ? 'left' : 'center')}
                 compact={compact}
                 effect={


### PR DESCRIPTION
## Summary
- keep tag and tag-group layout props transient so React never receives them as native DOM attributes
- avoid forwarding Reqore theme objects to native popover trigger elements
- cover both cases with DOM-attribute regression tests

## Verification
- 717 ReQore unit tests pass
- production TypeScript build passes