### PR TITLE
feat(Timeline): add `spacing` prop for icons-only vertical timelines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.70.11",
+  "version": "0.70.12",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/Timeline/index.tsx
+++ b/src/components/Timeline/index.tsx
@@ -121,6 +121,16 @@ export interface IReqoreTimelineProps
    */
   responsive?: boolean;
   /**
+   * Minimum vertical gap between markers — i.e. the length of the connector
+   * line — in `direction='vertical'`. A `TSizes` maps to a sensible pixel value;
+   * a `number` is used as raw pixels. Without it an icons-only timeline (items
+   * with no `title`, `content` or `timestamp`) collapses every row to the marker
+   * height, so the connector line has zero length and disappears — set `spacing`
+   * to keep the line visible. Acts as a floor: rows that are already taller (rich
+   * content) are unaffected. Ignored for `direction='horizontal'`.
+   */
+  spacing?: TSizes | number;
+  /**
    * Controlled collapsed state — map of item index to collapsed boolean.
    * When provided, the component becomes controlled for those indices.
    * Items not in the map fall back to their own `isCollapsed` prop.
@@ -151,6 +161,8 @@ export interface IReqoreTimelineItemStyle extends IReqoreTimelineStyle {
   isCollapsed?: boolean;
   /** Render the connector line dotted (used around a collapsed run). */
   dashed?: boolean;
+  /** Minimum connector length (px) below this marker; vertical mode only. */
+  spacing?: number;
 }
 
 // Size of the timeline marker (icon container) - made smaller
@@ -162,6 +174,19 @@ const MARKER_SIZE_FROM_SIZE: Record<TSizes, number> = {
   big: 32,
   huge: 40,
   massive: 50,
+};
+
+// Default connector-line length (vertical gap between markers) for
+// `spacing='<size>'`. Chosen so an icons-only timeline reads as a clear
+// line-with-dots at every size.
+const SPACING_FROM_SIZE: Record<TSizes, number> = {
+  micro: 8,
+  tiny: 10,
+  small: 14,
+  normal: 18,
+  big: 24,
+  huge: 32,
+  massive: 44,
 };
 
 // Line width for the connector
@@ -219,6 +244,16 @@ const StyledTimelineItem = styled.li<IReqoreTimelineItemStyle>`
           display: none;
         `}
       }
+    `}
+
+  ${({ direction, spacing, isLast, size }) =>
+    direction !== 'horizontal' &&
+    spacing !== undefined &&
+    !isLast &&
+    css`
+      /* Floor the row height so the connector line (which runs from the marker
+         to the item's bottom edge) has length even when the row has no content. */
+      min-height: ${MARKER_SIZE_FROM_SIZE[size] + spacing}px;
     `}
 
   ${({ disabled }) =>
@@ -405,6 +440,8 @@ interface ITimelineItemRendererProps {
   baseTheme: IReqoreTheme;
   isCollapsed: boolean;
   direction: 'vertical' | 'horizontal';
+  /** Minimum connector length (px) below this marker; vertical mode only. */
+  spacing?: number;
   /** Draw this item's downward connector dotted (next to a collapsed run). */
   lineDashed?: boolean;
   onToggle: (event: React.MouseEvent) => void;
@@ -422,6 +459,7 @@ const TimelineItemRenderer = memo(
     baseTheme,
     isCollapsed,
     direction,
+    spacing,
     lineDashed,
     onToggle,
     onItemClick,
@@ -440,6 +478,7 @@ const TimelineItemRenderer = memo(
         theme={itemTheme}
         size={size}
         direction={direction}
+        spacing={spacing}
         isClickable={isClickable}
         isLast={isLast}
         disabled={item.disabled}
@@ -473,6 +512,7 @@ const TimelineItemRenderer = memo(
               size={size}
               isLast={isLast}
               dashed={lineDashed}
+              className='reqore-timeline-line'
             />
           )}
         </StyledTimelineMarkerWrapper>
@@ -566,6 +606,8 @@ interface ICollapsedRunRendererProps {
   size: TSizes;
   baseTheme: IReqoreTheme;
   expanded: boolean;
+  /** Minimum connector length (px) below the marker; vertical mode only. */
+  spacing?: number;
   onToggle: () => void;
 }
 
@@ -575,7 +617,7 @@ interface ICollapsedRunRendererProps {
  * "Hide" control that re-folds them). Vertical mode only.
  */
 const CollapsedRunRenderer = memo(
-  ({ range, isLast, size, baseTheme, expanded, onToggle }: ICollapsedRunRendererProps) => {
+  ({ range, isLast, size, baseTheme, expanded, spacing, onToggle }: ICollapsedRunRendererProps) => {
     const n = range.collapsedItems.length;
     // Hex for the icon (ReqoreIcon `color` wants a TReqoreEffectColor); rgba for
     // the label's plain CSS colour. Both muted to read as "skipped".
@@ -587,6 +629,7 @@ const CollapsedRunRenderer = memo(
         theme={baseTheme}
         size={size}
         direction='vertical'
+        spacing={spacing}
         isClickable
         isLast={isLast}
         onClick={onToggle}
@@ -619,6 +662,7 @@ const CollapsedRunRenderer = memo(
               size={size}
               isLast={isLast}
               dashed={!expanded}
+              className='reqore-timeline-line'
             />
           )}
         </StyledTimelineMarkerWrapper>
@@ -655,6 +699,7 @@ const ReqoreTimeline = memo(
         className,
         direction: directionProp = 'vertical',
         responsive = true,
+        spacing,
         collapsedState,
         onCollapseChange,
         onRangeToggle,
@@ -669,6 +714,15 @@ const ReqoreTimeline = memo(
       // mobile unless the caller explicitly opts out via `responsive={false}`.
       const direction =
         responsive && isMobile && directionProp === 'horizontal' ? 'vertical' : directionProp;
+
+      // Resolve `spacing` (TSizes | number | undefined) to a pixel connector
+      // length once, then hand it to every row.
+      const resolvedSpacing =
+        spacing === undefined
+          ? undefined
+          : typeof spacing === 'number'
+            ? spacing
+            : SPACING_FROM_SIZE[spacing];
 
       // Internal collapse state for TOP-LEVEL items (uncontrolled mode). Folded
       // runs are skipped here — they carry their own expand state below.
@@ -858,6 +912,7 @@ const ReqoreTimeline = memo(
                   size={size}
                   baseTheme={baseTheme}
                   expanded={row.expanded}
+                  spacing={resolvedSpacing}
                   onToggle={row.onToggle}
                 />
               );
@@ -878,6 +933,7 @@ const ReqoreTimeline = memo(
                 intent={intent}
                 baseTheme={baseTheme}
                 direction={direction}
+                spacing={resolvedSpacing}
                 isCollapsed={row.isCollapsed}
                 lineDashed={lineDashed}
                 onToggle={row.onToggle}

--- a/src/stories/Timeline/Timeline.stories.tsx
+++ b/src/stories/Timeline/Timeline.stories.tsx
@@ -967,5 +967,10 @@ export const IconsOnlyVertical: Story = {
     const firstItem = canvasElement.querySelector('.reqore-timeline-item') as HTMLElement;
     await userEvent.click(firstItem);
     await expect(onOverviewClick).toHaveBeenCalled();
+
+    // Release focus so the story doesn't end with the item's focus-visible
+    // outline lingering as a rectangle over the timeline (Storybook captures
+    // the story after `play` runs).
+    firstItem.blur();
   },
 };

--- a/src/stories/Timeline/Timeline.stories.tsx
+++ b/src/stories/Timeline/Timeline.stories.tsx
@@ -1,4 +1,4 @@
-import { expect, within } from 'storybook/test';
+import { expect, fn, userEvent, within } from 'storybook/test';
 import { StoryFn, StoryObj } from '@storybook/react';
 import { useCallback, useEffect, useState } from 'react';
 import { _testsClickButton } from '../../../__tests__/utils';
@@ -928,5 +928,44 @@ export const CollapsedRange: Story = {
     // between two collapsed runs.
     await expect(canvas.getByText('Build #11')).toBeInTheDocument();
     await expect(canvas.getByText('Build #7')).toBeInTheDocument();
+  },
+};
+
+// Icon markers with no title/content/timestamp — a compact "section rail". The
+// `spacing` prop is what keeps the connector line visible here; without it every
+// row collapses to the marker height and the line vanishes.
+const onOverviewClick = fn();
+const iconOnlyItems: IReqoreTimelineProps['items'] = [
+  { icon: 'FlagLine', tooltip: 'Overview', onClick: onOverviewClick },
+  { icon: 'ShoppingCartLine', tooltip: 'Orders', onClick: fn() },
+  { icon: 'BankCardLine', tooltip: 'Billing', onClick: fn() },
+  { icon: 'TruckLine', tooltip: 'Shipping', onClick: fn() },
+  { icon: 'CheckboxCircleLine', tooltip: 'Done', onClick: fn() },
+];
+
+export const IconsOnlyVertical: Story = {
+  render: Template,
+  args: {
+    direction: 'vertical',
+    size: 'small',
+    spacing: 'normal',
+    items: iconOnlyItems,
+  },
+  play: async ({ canvasElement }) => {
+    // Every marker renders even though the rows carry no text.
+    const markers = canvasElement.querySelectorAll('.reqore-timeline-marker');
+    await expect(markers.length).toBe(iconOnlyItems.length);
+
+    // The connector line has real length thanks to `spacing`. Without the prop
+    // an icons-only vertical timeline collapses each row to the marker height,
+    // so the line is 0px tall — this assertion is the regression guard.
+    const line = canvasElement.querySelector('.reqore-timeline-line') as HTMLElement;
+    await expect(line).toBeTruthy();
+    await expect(line.getBoundingClientRect().height).toBeGreaterThan(0);
+
+    // Icon markers are clickable — the section-switcher use case relies on it.
+    const firstItem = canvasElement.querySelector('.reqore-timeline-item') as HTMLElement;
+    await userEvent.click(firstItem);
+    await expect(onOverviewClick).toHaveBeenCalled();
   },
 };


### PR DESCRIPTION
## What

Adds an optional `spacing?: TSizes | number` to `ReqoreTimeline`.

## Why

A **vertical** timeline whose items carry no `title` / `content` / `timestamp` — e.g. a compact **icons-only "section rail"** — collapses every row to the marker height. The connector line runs from the marker to the row's bottom edge, so with zero extra height it has **zero length and disappears**: the markers touch and there's no "timeline line" at all.

There was no prop to control inter-marker spacing, so this look wasn't achievable without CSS overrides on the internals.

## How

- `spacing` floors each **non-last** row's height to `marker + spacing` in vertical mode, so the connector always has length.
- It's a **minimum** — content-rich rows that are already taller are unaffected.
- Ignored in `direction='horizontal'`.
- `TSizes` maps to a sensible per-size pixel value (`SPACING_FROM_SIZE`); a `number` is raw pixels.
- The connector element now carries a `reqore-timeline-line` class for styling/testing.

```tsx
<ReqoreTimeline
  direction='vertical'
  size='small'
  spacing='normal'
  items={sections.map((s) => ({ icon: s.icon, tooltip: s.title, onClick: () => go(s) }))}
/>
```

## Tests

- New **"Icons Only (Vertical)"** story with a play test asserting the connector renders with real height (fails without the prop) and that the icon markers are clickable.
- `yarn test` — 715 unit tests pass; `yarn test:stories` (Timeline) — all pass.
- No new type errors (the component file typechecks clean; the pre-existing `build:test` failures are unrelated files).

Additive and backwards-compatible — no behaviour change when `spacing` is omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)