### PR TITLE
chore(release): bump version to 0.70.17 (unblock beta publish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.70.16",
+  "version": "0.70.17",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Fixes the failed `beta_release` publish on develop.

#590 (the docs-only "point at instruction-files rules" PR) merged **without a version bump**, so `beta_release.yml` tried to re-publish `0.70.16` — already on NPM — and [failed](https://github.com/qoretechnologies/reqore/actions/workflows/beta_release.yml). Per this repo's own rule (`.claude/CLAUDE.md` → "Version bumps (required on every PR)"), every push to develop must carry a new version. This patch bump `0.70.16` → `0.70.17` restores a publishable version.

My fault on #590 — I skipped the bump on a docs-only PR; the rule is "every PR", no exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)