### PR TITLE
feat(NavRail): add maxItems cap for the primary marks

### DIFF
--- a/__tests__/NavRail.test.tsx
+++ b/__tests__/NavRail.test.tsx
@@ -104,6 +104,25 @@ test('Renders with the standard prop contract (size/intent/effect/flat/raised/ra
   expect(screen.getByRole('group', { name: 'Dashboard sections' })).toBeInTheDocument();
 });
 
+test('maxItems caps the visible primary marks and folds the rest into the ⋮ menu', () => {
+  renderRail(<ReqoreNavRail items={ITEMS} defaultActiveId='dashboard' maxItems={2} />);
+
+  // Only the first two marks show; the third folds away behind the overflow.
+  expect(screen.getByRole('button', { name: 'Dashboard' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Team' })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Settings' })).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'More items' })).toBeInTheDocument();
+});
+
+test('maxItems keeps the active mark visible by windowing around it', () => {
+  // Active 'settings' (index 2) is outside the first two — the window slides so
+  // it stays visible and an earlier mark folds away instead.
+  renderRail(<ReqoreNavRail items={ITEMS} activeId='settings' maxItems={2} />);
+
+  expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Dashboard' })).not.toBeInTheDocument();
+});
+
 test('Clicking a sub-item with a scrollTargetId scrolls to that element', () => {
   const scrollIntoView = vi.fn();
   Element.prototype.scrollIntoView = scrollIntoView;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/reqore",
-  "version": "0.71.0",
+  "version": "0.71.1",
   "description": "ReQore is a highly theme-able and modular UI library for React",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/NavRail/index.tsx
+++ b/src/components/NavRail/index.tsx
@@ -114,6 +114,11 @@ export interface IReqoreNavRailProps
   /** Cap used to fold overflow into the `⋮` menu. A number is taken as px; when
    *  omitted and `floating`, the positioned ancestor's height is measured. */
   maxHeight?: number;
+  /** Hard cap on the number of primary marks shown at once — the rest fold into
+   *  the `⋮` menu regardless of available height. Combines with `maxHeight`
+   *  (the lower of the two wins), so a short viewport can still show fewer. Does
+   *  not cap the active page's sub-items. */
+  maxItems?: number;
   /** Surface radius. Round (pill, matching the circular marks) by default;
    *  `radiusSize` overrides with a fixed size; `rounded={false}` squares it. */
   rounded?: boolean;
@@ -428,6 +433,7 @@ export const ReqoreNavRail = memo(
     scrollContainer,
     scrollSpy,
     maxHeight,
+    maxItems,
     size = 'small',
     intent,
     effect,
@@ -515,6 +521,11 @@ export const ReqoreNavRail = memo(
       subMax = Number.isFinite(slots)
         ? Math.min(subItems.length, Math.max(2, slots - itemMax))
         : subItems.length;
+    }
+    // Hard count cap: the lower of the height budget and `maxItems` wins, so a
+    // short viewport can still show fewer than the cap.
+    if (typeof maxItems === 'number') {
+      itemMax = Math.min(itemMax, Math.max(1, Math.floor(maxItems)));
     }
 
     const { shown: itemsShown, hidden: itemsHidden } = splitAroundActive(items, activeItemId, itemMax);

--- a/src/stories/NavRail/NavRail.stories.tsx
+++ b/src/stories/NavRail/NavRail.stories.tsx
@@ -111,6 +111,14 @@ const Labeled = ({ label, children }: { label: string; children: ReactNode }) =>
  *  page marks with the active page's sections nested in the sub-capsule. */
 export const Inline: Story = {
   args: { items: ITEMS, position: 'static', defaultActiveId: 'dashboard' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Renders the rail on its own (`position='static'`) — a thin pill of circular page marks with the Dashboard page active and its sections nested in the sub-capsule directly beneath it.",
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole('navigation')).toBeInTheDocument();
@@ -123,6 +131,14 @@ export const Inline: Story = {
  *  (compare with Inline). */
 export const NoSections: Story = {
   args: { items: ITEMS, position: 'static', defaultActiveId: 'reports' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the inline rail with an active page (Reports) that has no sub-items, so no sub-capsule appears — yet the rail stays exactly the same width as when the active page has sections (compare with Inline).',
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole('navigation')).toBeInTheDocument();
@@ -133,6 +149,14 @@ export const NoSections: Story = {
 /** IN GUTTER — floating in the left gutter of a page, over scrolling content. */
 export const InGutter: Story = {
   args: { items: ITEMS, floating: true, position: 'left', defaultActiveId: 'dashboard' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Renders the rail floating in the left gutter of a page (`floating`, `position='left'`) over scrolling content, Dashboard active.",
+      },
+    },
+  },
   render: (args: IReqoreNavRailProps) => (
     <Backdrop>
       <ReqoreNavRail {...args} />
@@ -143,6 +167,14 @@ export const InGutter: Story = {
 /** RIGHT GUTTER — the same rail pinned to the right gutter. */
 export const RightGutter: Story = {
   args: { items: ITEMS, floating: true, position: 'right', defaultActiveId: 'dashboard' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Renders the same floating rail pinned to the right gutter (`position='right'`), Dashboard active.",
+      },
+    },
+  },
   render: (args: IReqoreNavRailProps) => (
     <Backdrop>
       <ReqoreNavRail {...args} />
@@ -152,6 +184,14 @@ export const RightGutter: Story = {
 
 /** SIZES — the standard `size` scale drives the marks, spacing and pill radius. */
 export const Sizes: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the rail at each `size` in the standard scale (tiny, small, normal, big) side by side, showing how size drives the marks, spacing and pill radius.',
+      },
+    },
+  },
   render: () => (
     <ReqoreControlGroup gapSize='big' verticalAlign='flex-start'>
       {(['tiny', 'small', 'normal', 'big'] as const).map((size) => (
@@ -165,6 +205,14 @@ export const Sizes: Story = {
 
 /** INTENTS — `intent` sets the active-mark accent (per-item `intent` overrides). */
 export const Intents: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the rail at each `intent` (info, success, warning, danger, muted) side by side, showing how intent sets the active-mark accent (a per-item `intent` would override it).',
+      },
+    },
+  },
   render: () => (
     <ReqoreControlGroup gapSize='big' verticalAlign='flex-start'>
       {(['info', 'success', 'warning', 'danger', 'muted'] as const).map((intent) => (
@@ -178,6 +226,14 @@ export const Intents: Story = {
 
 /** EFFECTS — the standard `effect` prop paints the rail surface. */
 export const Effects: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the rail with the standard `effect` prop painting the surface — a gradient variant (paired with a coordinated `activeEffect` on the active group) and a glow variant.',
+      },
+    },
+  },
   render: () => (
     <ReqoreControlGroup gapSize='big' verticalAlign='flex-start'>
       <Labeled label='gradient'>
@@ -204,6 +260,14 @@ export const Effects: Story = {
 
 /** FLAT & RAISED — `flat` drops the border, `raised` adds the 3D inset. */
 export const FlatAndRaised: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the rail in three surface treatments side by side — bordered (default), `flat` (border dropped), and `flat` + `raised` (the 3D inset).',
+      },
+    },
+  },
   render: () => (
     <ReqoreControlGroup gapSize='big' verticalAlign='flex-start'>
       <Labeled label='bordered (default)'>
@@ -227,6 +291,14 @@ export const IdleReveal: Story = {
     position: 'left',
     idleReveal: true,
     defaultActiveId: 'dashboard',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the floating rail with `idleReveal`. The play function asserts the full behaviour: it rests dimmed (opacity 0.34), fades fully in when the gutter is hovered, and dims again when the mouse leaves.',
+      },
+    },
   },
   render: (args: IReqoreNavRailProps) => (
     <Backdrop>
@@ -257,6 +329,14 @@ export const IdleResting: Story = {
     idleReveal: true,
     defaultActiveId: 'dashboard',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the floating `idleReveal` rail with NO interaction, capturing its resting dimmed state (opacity 0.34) — the play only asserts the dim, it never hovers.',
+      },
+    },
+  },
   render: (args: IReqoreNavRailProps) => (
     <Backdrop>
       <ReqoreNavRail {...args} />
@@ -278,6 +358,14 @@ export const Collapsed: Story = {
     maxHeight: 280,
     defaultActiveId: 'dashboard',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the floating rail in a short viewport (`maxHeight: 280`) so each group folds its extras into a `⋮` flyout that never widens the rail.',
+      },
+    },
+  },
   render: (args: IReqoreNavRailProps) => (
     <Backdrop height={320}>
       <ReqoreNavRail {...args} />
@@ -294,6 +382,14 @@ export const OverflowMenu: Story = {
     position: 'left',
     maxHeight: 280,
     defaultActiveId: 'dashboard',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Renders the collapsed rail and opens its `⋮` flyout (play), capturing the floating menu of hidden items — ending with 'Settings' visible in the menu.",
+      },
+    },
   },
   render: (args: IReqoreNavRailProps) => (
     <Backdrop height={320}>
@@ -317,6 +413,14 @@ export const MaxItems: Story = {
     maxItems: 4,
     defaultActiveId: 'dashboard',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the inline rail with `maxItems={4}`, capping it to four primary marks (Dashboard active, its sections nested beneath) regardless of viewport height. The remaining three pages — Automations, Integrations, Settings — fold into the ⋮ overflow menu, which the play function opens so they appear in the snapshot.',
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     // A capped-out page is absent from the rail until the ⋮ menu is opened.
@@ -335,6 +439,14 @@ export const TallContent: Story = {
     position: 'left',
     scrollSpy: true,
     defaultActiveId: 'dashboard',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the floating rail with `scrollSpy` over tall (doubled) content. The play asserts the current section follows the scroll position and that clicking a section scrolls the page to it.',
+      },
+    },
   },
   render: (args: IReqoreNavRailProps) => {
     const scrollRef = useRef<HTMLDivElement>(null);
@@ -375,6 +487,14 @@ export const Mobile: Story = {
     scrollHideDelay: 60000,
     defaultActiveId: 'dashboard',
   },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the floating rail with `revealOnScroll` in a phone-width frame — hidden at rest (opacity 0), revealed while the user scrolls. The play asserts both states.',
+      },
+    },
+  },
   render: (args: IReqoreNavRailProps) => {
     const scrollRef = useRef<HTMLDivElement>(null);
     return (
@@ -398,6 +518,14 @@ export const Mobile: Story = {
 /** INTERACTION — navigating a primary item swaps its nested section sub-capsule. */
 export const Interaction: Story = {
   args: { items: ITEMS, position: 'static', defaultActiveId: 'dashboard' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Renders the inline rail and navigates from Dashboard to Team (play), asserting the nested section sub-capsule swaps to the Team sections.',
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole('group', { name: 'Dashboard sections' })).toBeInTheDocument();

--- a/src/stories/NavRail/NavRail.stories.tsx
+++ b/src/stories/NavRail/NavRail.stories.tsx
@@ -307,6 +307,25 @@ export const OverflowMenu: Story = {
   },
 };
 
+/** MAX ITEMS — a hard cap on how many primary marks show at once (here 4),
+ *  independent of viewport height; the rest fold into the `⋮` menu. Opening the
+ *  menu (play) reveals a capped-out page. */
+export const MaxItems: Story = {
+  args: {
+    items: ITEMS,
+    position: 'static',
+    maxItems: 4,
+    defaultActiveId: 'dashboard',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // A capped-out page is absent from the rail until the ⋮ menu is opened.
+    await expect(canvas.queryByRole('button', { name: 'Settings' })).not.toBeInTheDocument();
+    await userEvent.click(canvas.getByRole('button', { name: 'More items' }));
+    await waitFor(() => expect(document.body.textContent).toContain('Settings'));
+  },
+};
+
 /** TALL CONTENT — clicking a section scrolls the page to it (and `scrollSpy`
  *  highlights the section you scroll to). */
 export const TallContent: Story = {


### PR DESCRIPTION
## What

Adds a `maxItems?: number` prop to `ReqoreNavRail` — a hard cap on how many **primary marks** show at once. The rest fold into the `⋮` overflow menu, regardless of available height.

- Combines with `maxHeight` — the **lower** of the two wins, so a short viewport can still show fewer than the cap.
- Never caps the active page's **sub-items** (sections), only the pages.
- The active mark always stays visible: when it falls outside the cap, the existing window slides to include it.

## Why

Consumers that want a tight, viewport-independent rail — e.g. a "most-visited" nav that shows the top ~12 destinations with everything else one click away in `⋮` — currently have to reverse-engineer a pixel `maxHeight` from the rail's internal mark sizing (`SIZE_TO_PX + GAP_FROM_SIZE`, `reserve`, …). That's brittle and duplicates internals. `maxItems` expresses the intent directly.

First consumer: the qorus-ide navigation rail (top-level page catalogue capped to the most-visited pages).

## Tests
- Unit: `maxItems` caps visible marks + folds the rest into `⋮`; active mark stays visible via windowing.
- Story: `Navigation/Nav Rail › MaxItems` (play-test opens the `⋮` and asserts a capped-out page appears).
- `yarn precheck`: lint clean, 745 tests pass, prod build clean.

## Version
`0.71.0` → `0.71.1` (new prop, patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)